### PR TITLE
[MARS 289] Invalid date used when creating new Project

### DIFF
--- a/client/src/pages/create/Project.tsx
+++ b/client/src/pages/create/Project.tsx
@@ -96,7 +96,7 @@ const Project = () => {
         <Flex direction={"column"} gap={"6"} p={"2"} h={"100%"}>
           <FormControl isRequired isInvalid={isNameError}>
             <FormLabel htmlFor={"name"} fontWeight={"normal"}>
-              Project Name
+              Name
             </FormLabel>
             <Input
               id={"name"}
@@ -201,11 +201,36 @@ const Project = () => {
           <ModalCloseButton />
           <ModalBody p={"2"}>
             <Flex direction={"column"} gap={"4"} p={"2"}>
-              <Heading size={"md"}>Overview</Heading>
               <Text>
-                Projects can be used to organize and share Entities. Any type of
-                Entity can be included in a Project. Entities can be added and
-                removed from a Project after it has been created.
+                Projects can be used to organize and share Entities.
+              </Text>
+              <Text>
+                Any type of Entity can be included in a Project. Entities can be
+                added and removed from a Project after it has been created.
+              </Text>
+
+              <Heading size={"sm"}>Name*</Heading>
+              <Text>
+                Specify the name of a Project. This should be unique and will
+                act as a searchable identifier.
+              </Text>
+
+              <Heading size={"sm"}>Date Created or Started</Heading>
+              <Text>
+                A timestamp assigned to the Project. For example, if this is a
+                set of Entities used in a specific experiment, this date could
+                represent when work on the experiment commenced. Otherwise,
+                this timestamp may simply represent when this Project was created
+                in MARS.
+              </Text>
+
+              <Heading size={"sm"}>Description*</Heading>
+              <Text>
+                A brief description of the Project contents.
+              </Text>
+
+              <Text>
+                <i>* Required field</i>
               </Text>
             </Flex>
           </ModalBody>

--- a/client/src/pages/create/Project.tsx
+++ b/client/src/pages/create/Project.tsx
@@ -110,19 +110,19 @@ const Project = () => {
             />
             {isNameError && (
               <FormErrorMessage>
-                A name or ID must be specified.
+                A name to identify the Project must be specified.
               </FormErrorMessage>
             )}
           </FormControl>
 
           <FormControl>
             <FormLabel htmlFor="date" fontWeight={"normal"}>
-              Created
+              Date Created or Started
             </FormLabel>
 
             <Input
               w={["100%", "md"]}
-              type={"date"}
+              type={"datetime-local"}
               value={created}
               onChange={(event) =>
                 setCreated(dayjs(event.target.value).format("YYYY-MM-DDTHH:mm"))
@@ -130,7 +130,7 @@ const Project = () => {
             />
 
             <FormHelperText>
-              Specify a timestamp most significant to the Project.
+              Specify a timestamp for the Project.
             </FormHelperText>
           </FormControl>
 


### PR DESCRIPTION
## Description

Changed input from `date` to `datetime-local`, allowing the time to be picked as well as the date. `dayjs` was already creating a timestamp in `datetime-local`, but the `date`-style input did not accept it. You can now specify a date and time with no console warning.

Updated information modal for Project as well, added detail on fields and which ones are required.

## Ticket

https://dev.azure.com/gt-sse-center/MARS%202023/_workitems/edit/289/

## Demo 🎥

Please provide any images, GIFs, or videos that show the effect of your changes (if applicable). A picture is worth a thousand words.


