### PR TITLE
[MARS-295] remove isNameUnique on client

### DIFF
--- a/client/src/pages/create/Entity.tsx
+++ b/client/src/pages/create/Entity.tsx
@@ -745,7 +745,7 @@ const Entity = () => {
               )
             }
             onClick={onPageNext}
-            isDisabled={!isValidInput() || !isNameUnique || isNameError}
+            isDisabled={!isValidInput() || isNameError}
             isLoading={isSubmitting}
           >
             {_.isEqual("attributes", pageState) ? "Finish" : "Next"}


### PR DESCRIPTION
## Description

now allow 2 entities to have the same name

## Ticket

https://dev.azure.com/gt-sse-center/MARS%202023/_workitems/edit/295

## Demo 🎥

![image](https://github.com/Brain-Development-and-Disorders-Lab/mars/assets/11888851/256c5b04-3737-4938-9664-a5cf618b57a2)

backend was already disabled:
`      let existingEntity = await getDatabase().collection(ENTITIES).findOne({
        $or: [
          { _id: entityData?._id },  // Check by _id
          // { name: entityData?.name } // Check by name
        ]
      });`
