### PR TITLE
[MARS 296] Attributes with IDs containing `_` not included in CSV exports

### DIFF
--- a/server/src/operations/Entities.ts
+++ b/server/src/operations/Entities.ts
@@ -1486,7 +1486,7 @@ export class Entities {
               } else if (_.startsWith(field, "origin_")) {
                 // "origins" data field
                 row.push(
-                  Entities.getOne(_.split(field, "_")[1]).then((entity) => {
+                  Entities.getOne(field.slice(7)).then((entity) => {
                     headers.push(`Origin (${entity?.name})`);
                     return entity?.name;
                   })
@@ -1494,14 +1494,14 @@ export class Entities {
               } else if (_.startsWith(field, "product_")) {
                 // "products" data field
                 row.push(
-                  Entities.getOne(_.split(field, "_")[1]).then((entity) => {
+                  Entities.getOne(field.slice(8)).then((entity) => {
                     headers.push(`Product (${entity?.name})`);
                     return entity?.name;
                   })
                 );
               } else if (_.startsWith(field, "attribute_")) {
                 // "attributes" data field
-                const attributeId = field.split("_")[1];
+                const attributeId = field.slice(10);
                 entity?.attributes?.map((attribute) => {
                   if (_.isEqual(attribute?._id, attributeId)) {
                     for (let value of attribute.values) {

--- a/server/src/operations/Entities.ts
+++ b/server/src/operations/Entities.ts
@@ -1547,7 +1547,7 @@ export class Entities {
             } as { [key: string]: any };
             const exportOperations = [] as Promise<string>[];
 
-            exportInfo.fields?.map((field) => {
+            exportInfo.fields?.map((field: string) => {
               if (_.isEqual(field, "created")) {
                 // "created" data field
                 tempStructure["created"] = dayjs(entity.created)
@@ -1559,11 +1559,11 @@ export class Entities {
               } else if (_.isEqual(field, "description")) {
                 // "description" data field
                 tempStructure["description"] = entity.description;
-              } else if (_.startsWith(field, "project")) {
+              } else if (_.startsWith(field, "project_")) {
                 // "projects" data field
                 tempStructure["projects"] = [];
                 exportOperations.push(
-                  Projects.getOne(_.split(field, "_")[1]).then((project) => {
+                  Projects.getOne(field.slice(8)).then((project) => {
                     tempStructure["projects"].push(project?.name);
                     return project?.name;
                   })
@@ -1572,7 +1572,7 @@ export class Entities {
                 // "origins" data field
                 tempStructure.associations["origins"] = [];
                 exportOperations.push(
-                  Entities.getOne(_.split(field, "_")[1]).then((entity) => {
+                  Entities.getOne(field.slice(7)).then((entity) => {
                     tempStructure.associations["origins"].push(entity?.name);
                     return entity?.name;
                   })
@@ -1581,7 +1581,7 @@ export class Entities {
                 // "products" data field
                 tempStructure.associations["products"] = [];
                 exportOperations.push(
-                  Entities.getOne(_.split(field, "_")[1]).then((entity) => {
+                  Entities.getOne(field.slice(8)).then((entity) => {
                     tempStructure.associations["products"].push(entity?.name);
                     return entity?.name;
                   })
@@ -1589,7 +1589,7 @@ export class Entities {
               } else if (_.startsWith(field, "attribute_")) {
                 // "attributes" data field
                 tempStructure["attributes"] = [];
-                const attributeId = field.split("_")[1];
+                const attributeId = field.slice(10);
                 entity?.attributes?.map((attribute) => {
                   if (_.isEqual(attribute?._id, attributeId)) {
                     // Add the Attribute to the exported set
@@ -1629,7 +1629,7 @@ export class Entities {
             const textProducts = [] as string[];
             const textAttributes = [] as string[];
 
-            exportInfo.fields?.map((field) => {
+            exportInfo.fields?.map((field: string) => {
               if (_.isEqual(field, "created")) {
                 // "created" data field
                 textDetails.push(
@@ -1646,7 +1646,7 @@ export class Entities {
               } else if (_.startsWith(field, "origin_")) {
                 // "origins" data field
                 exportOperations.push(
-                  Entities.getOne(_.split(field, "_")[1]).then((entity) => {
+                  Entities.getOne(field.slice(7)).then((entity) => {
                     textOrigins.push(entity?.name);
                     return entity?.name;
                   })
@@ -1654,14 +1654,14 @@ export class Entities {
               } else if (_.startsWith(field, "product_")) {
                 // "products" data field
                 exportOperations.push(
-                  Entities.getOne(_.split(field, "_")[1]).then((entity) => {
+                  Entities.getOne(field.slice(8)).then((entity) => {
                     textProducts.push(entity?.name);
                     return entity?.name;
                   })
                 );
               } else if (_.startsWith(field, "attribute_")) {
                 // "attributes" data field
-                const attributeId = field.split("_")[1];
+                const attributeId = field.slice(10);
                 entity?.attributes?.map((attribute) => {
                   if (_.isEqual(attribute?._id, attributeId)) {
                     // Extract all values

--- a/server/src/operations/Projects.ts
+++ b/server/src/operations/Projects.ts
@@ -445,7 +445,7 @@ export class Projects {
             const projects: Promise<string>[] = [];
 
             // Iterate over fields and generate a CSV export file
-            projectExportData.fields.map((field) => {
+            projectExportData.fields.map((field: string) => {
               if (_.isEqual(field, "created")) {
                 // "created" data field
                 headers.push("Created");
@@ -465,14 +465,14 @@ export class Projects {
               } else if (_.startsWith(field, "project_")) {
                 // "project" data fields
                 projects.push(
-                  Projects.getOne(_.split(field, "_")[1]).then((project) => {
+                  Projects.getOne(field.slice(8)).then((project) => {
                     return project.name;
                   })
                 );
               } else if (_.startsWith(field, "entity_")) {
                 // "entity" data fields
                 entities.push(
-                  Entities.getOne(_.split(field, "_")[1]).then((entity) => {
+                  Entities.getOne(field.slice(7)).then((entity) => {
                     return entity?.name ?? "";
                   })
                 );
@@ -528,7 +528,7 @@ export class Projects {
             } as { [key: string]: any };
             const exportOperations = [] as Promise<string>[];
 
-            projectExportData.fields.map((field) => {
+            projectExportData.fields.map((field: string) => {
               if (_.isEqual(field, "created")) {
                 // "created" data field
                 tempStructure["created"] = dayjs(project.created)
@@ -540,11 +540,11 @@ export class Projects {
               } else if (_.isEqual(field, "description")) {
                 // "description" data field
                 tempStructure["description"] = project.description;
-              } else if (_.startsWith(field, "project")) {
+              } else if (_.startsWith(field, "project_")) {
                 // "project" data fields
                 tempStructure["projects"] = [];
                 exportOperations.push(
-                  Projects.getOne(_.split(field, "_")[1]).then((project) => {
+                  Projects.getOne(field.slice(8)).then((project) => {
                     tempStructure["projects"].push(project.name);
                     return project.name;
                   })
@@ -552,7 +552,7 @@ export class Projects {
               } else if (_.startsWith(field, "entity_")) {
                 // "entity" data fields
                 exportOperations.push(
-                  Entities.getOne(_.split(field, "_")[1]).then((entity) => {
+                  Entities.getOne(field.slice(7)).then((entity) => {
                     tempStructure["entities"].push(entity.name);
                     return entity.name;
                   })
@@ -589,7 +589,7 @@ export class Projects {
             const textProjects = [] as string[];
             const textEntities = [] as string[];
 
-            projectExportData.fields.map((field) => {
+            projectExportData.fields.map((field: string) => {
               if (_.isEqual(field, "created")) {
                 // "created" data field
                 textDetails.push(
@@ -606,7 +606,7 @@ export class Projects {
               } else if (_.startsWith(field, "project_")) {
                 // "project" data fields
                 exportOperations.push(
-                  Projects.getOne(_.split(field, "_")[1]).then((project) => {
+                  Projects.getOne(field.slice(8)).then((project) => {
                     textProjects.push(project.name);
                     return project.name;
                   })
@@ -614,7 +614,7 @@ export class Projects {
               } else if (_.startsWith(field, "entity_")) {
                 // "entity" data fields
                 exportOperations.push(
-                  Entities.getOne(_.split(field, "_")[1]).then((entity) => {
+                  Entities.getOne(field.slice(7)).then((entity) => {
                     textEntities.push(entity.name);
                     return entity.name;
                   })


### PR DESCRIPTION
## Description

* Replaced `split` calls with `slice`. `split` was being used to remove a string prefix, so if the suffix included `_`, the remainder of the suffix would not be included, meaning the incorrect Entity field (Attribute, Project, Origin etc.) would not be included. `slice` was used to only remove the prefix, since the length of the prefix was known.

## Ticket

https://dev.azure.com/gt-sse-center/MARS%202023/_workitems/edit/296

## Demo 🎥

Please provide any images, GIFs, or videos that show the effect of your changes (if applicable). A picture is worth a thousand words.


