### PR TITLE
[MARS 299] Improve left menu design with contrast

### DIFF
--- a/client/src/components/AttributeViewButton/index.tsx
+++ b/client/src/components/AttributeViewButton/index.tsx
@@ -116,8 +116,8 @@ const AttributeViewButton = (props: AttributeViewButtonProps) => {
               h={"fit-content"}
               bg={"white"}
               rounded={"md"}
-              border={"1px"}
-              borderColor={"gray.100"}
+              border={"2px"}
+              borderColor={"gray.200"}
             >
               <Heading size={"md"}>Values</Heading>
               <Flex

--- a/client/src/components/Container/index.tsx
+++ b/client/src/components/Container/index.tsx
@@ -56,8 +56,6 @@ const Page: FC<PageProps> = ({ children }) => {
         p={"4"}
         justify={"center"}
         w={{ base: "100%", lg: "15%" }}
-        borderBottom={{ base: "1px", lg: "none" }}
-        borderColor={{ base: "gray.100", lg: "gray.100" }}
         bgGradient={"linear(to-br, gray.300, gray.200)"}
       >
         <Navigation />
@@ -66,8 +64,6 @@ const Page: FC<PageProps> = ({ children }) => {
       <Flex
         direction={"column"}
         w={{ base: "100%", lg: "85%" }}
-        borderLeft={{ base: "none", lg: "1px" }}
-        borderColor={{ base: "gray.100", lg: "gray.100" }}
       >
         {/* Search box component */}
         <Flex
@@ -76,8 +72,8 @@ const Page: FC<PageProps> = ({ children }) => {
           align={"center"}
           display={{ base: "none", lg: "flex" }}
           background={"white"}
-          borderBottom={"1px"}
-          borderColor={"gray.100"}
+          borderBottom={"2px"}
+          borderColor={"gray.200"}
         >
           <Spacer />
           <SearchBox />

--- a/client/src/components/Container/index.tsx
+++ b/client/src/components/Container/index.tsx
@@ -58,6 +58,7 @@ const Page: FC<PageProps> = ({ children }) => {
         w={{ base: "100%", lg: "15%" }}
         borderBottom={{ base: "1px", lg: "none" }}
         borderColor={{ base: "gray.100", lg: "gray.100" }}
+        bgGradient={"linear(to-br, gray.300, gray.200)"}
       >
         <Navigation />
       </Flex>

--- a/client/src/components/Container/index.tsx
+++ b/client/src/components/Container/index.tsx
@@ -72,7 +72,7 @@ const Page: FC<PageProps> = ({ children }) => {
           align={"center"}
           display={{ base: "none", lg: "flex" }}
           background={"white"}
-          borderBottom={"2px"}
+          borderBottom={"1px"}
           borderColor={"gray.200"}
         >
           <Spacer />

--- a/client/src/components/Icon/index.tsx
+++ b/client/src/components/Icon/index.tsx
@@ -35,7 +35,6 @@ import {
   BsGithub,
   BsGlobe,
   BsInfoCircleFill,
-  BsLightningFill,
   BsLink45Deg,
   BsList,
   BsLockFill,
@@ -53,6 +52,7 @@ import {
   BsZoomOut,
 } from "react-icons/bs";
 import { SiBox } from "react-icons/si";
+import { SlGraph } from "react-icons/sl";
 
 // Existing and custom types
 import { IconNames } from "@types";
@@ -73,7 +73,7 @@ const SYSTEM_ICONS: { [k: string]: IconType } = {
   attribute: BsTagFill,
 
   // Signal and action icons
-  activity: BsLightningFill,
+  activity: SlGraph,
   attachment: BsPaperclip,
   check: BsCheckCircleFill,
   info: BsInfoCircleFill,

--- a/client/src/components/Importer/index.tsx
+++ b/client/src/components/Importer/index.tsx
@@ -521,7 +521,7 @@ const Importer = (props: {
                       justify={"center"}
                       border={"2px"}
                       borderStyle={"dashed"}
-                      borderColor={"gray.100"}
+                      borderColor={"gray.200"}
                       rounded={"md"}
                       background={"gray.50"}
                     >

--- a/client/src/components/Linky/index.tsx
+++ b/client/src/components/Linky/index.tsx
@@ -48,6 +48,7 @@ const Linky = (props: LinkyProps) => {
       <Button
         variant={"link"}
         color={props.color ? props.color : "gray.700"}
+        justifyContent={props.justify ? props.justify: "center"}
         as={Link}
         onClick={onClickHandler}
       >

--- a/client/src/components/Navigation/index.tsx
+++ b/client/src/components/Navigation/index.tsx
@@ -10,7 +10,6 @@ import {
   Image,
   Heading,
   Text,
-  Divider,
   Spacer,
 } from "@chakra-ui/react";
 import Icon from "@components/Icon";
@@ -19,7 +18,6 @@ import Icon from "@components/Icon";
 import { useLocation, useNavigate } from "react-router-dom";
 
 // Utility functions and libraries
-import dayjs from "dayjs";
 import _ from "lodash";
 import Importer from "@components/Importer";
 
@@ -61,104 +59,101 @@ const Navigation = () => {
             <Heading fontWeight={"semibold"} size={"md"}>
               MARS
             </Heading>
-            <Text color={"gray.400"}>
-              {dayjs(Date.now()).format("ddd, DD MMM").toString()}
-            </Text>
           </Flex>
         </Flex>
 
         {/* Menu items */}
         <Flex direction={"column"} align={"self-start"} gap={"6"}>
-          <Button
-            key={"create"}
-            w={"100%"}
-            colorScheme={"green"}
-            variant={"solid"}
-            leftIcon={<Icon name={"add"} />}
-            onClick={() => navigate("/create")}
-          >
-            <Flex pr={"4"}>Create</Flex>
-          </Button>
+          <Flex direction={"column"} gap={"2"} width={"100%"}>
+            <Text fontSize={"xs"} fontWeight={"bold"} color={"gray.600"}>Actions</Text>
+            <Button
+                key={"create"}
+                w={"100%"}
+                colorScheme={"green"}
+                variant={"solid"}
+                leftIcon={<Icon name={"add"} />}
+                onClick={() => navigate("/create")}
+            >
+              <Flex pr={"4"}>Create</Flex>
+            </Button>
 
-          <Button
-            key={"import"}
-            w={"100%"}
-            colorScheme={"blue"}
-            variant={"solid"}
-            leftIcon={<Icon name={"upload"} />}
-            onClick={() => onImportOpen()}
-          >
-            <Flex pr={"4"}>Import</Flex>
-          </Button>
+            <Button
+                key={"import"}
+                w={"100%"}
+                colorScheme={"blue"}
+                variant={"solid"}
+                leftIcon={<Icon name={"upload"} />}
+                onClick={() => onImportOpen()}
+            >
+              <Flex pr={"4"}>Import</Flex>
+            </Button>
+          </Flex>
 
-          <Divider />
+          <Flex direction={"column"} gap={"2"} width={"100%"}>
+            <Text fontSize={"xs"} fontWeight={"bold"} color={"gray.600"}>Menu</Text>
+            <Button
+              key={"dashboard"}
+              w={"100%"}
+              justifyContent={"left"}
+              variant={_.isEqual(location.pathname, "/") ? "solid" : "ghost"}
+              leftIcon={<Icon name={"dashboard"} />}
+              onClick={() => navigate("/")}
+            >
+              Dashboard
+            </Button>
 
-          <Button
-            key={"dashboard"}
-            w={"100%"}
-            justifyContent={"left"}
-            variant={_.isEqual(location.pathname, "/") ? "solid" : "ghost"}
-            leftIcon={<Icon name={"dashboard"} />}
-            onClick={() => navigate("/")}
-          >
-            Dashboard
-          </Button>
+            <Button
+              key={"search"}
+              w={"100%"}
+              justifyContent={"left"}
+              variant={
+                _.includes(location.pathname, "/search") ? "solid" : "ghost"
+              }
+              leftIcon={<Icon name={"search"} />}
+              onClick={() => navigate("/search")}
+            >
+              Search
+            </Button>
 
-          <Divider />
+            <Button
+              leftIcon={<Icon name={"project"} />}
+              w={"100%"}
+              justifyContent={"left"}
+              variant={
+                _.includes(location.pathname, "/project") ? "solid" : "ghost"
+              }
+              onClick={() => navigate("/projects")}
+            >
+              <Flex w={"100%"} align={"center"} gap={"2"}>
+                <Text>Projects</Text>
+              </Flex>
+            </Button>
 
-          <Button
-            leftIcon={<Icon name={"project"} />}
-            w={"100%"}
-            justifyContent={"left"}
-            variant={
-              _.includes(location.pathname, "/project") ? "solid" : "ghost"
-            }
-            onClick={() => navigate("/projects")}
-          >
-            <Flex w={"100%"} align={"center"} gap={"2"}>
-              <Text>Projects</Text>
-            </Flex>
-          </Button>
-
-          <Button
-            leftIcon={<Icon name={"entity"} />}
-            w={"100%"}
-            justifyContent={"left"}
-            variant={
-              _.includes(location.pathname, "/entit") ? "solid" : "ghost"
-            }
-            onClick={() => navigate("/entities")}
-          >
-            <Flex w={"100%"} align={"center"} gap={"2"}>
-              <Text>Entities</Text>
-            </Flex>
-          </Button>
-          <Button
-            leftIcon={<Icon name={"attribute"} />}
-            w={"100%"}
-            justifyContent={"left"}
-            variant={
-              _.includes(location.pathname, "/attribute") ? "solid" : "ghost"
-            }
-            onClick={() => navigate("/attributes")}
-          >
-            Attributes
-          </Button>
-
-          <Divider />
-
-          <Button
-            key={"search"}
-            w={"100%"}
-            justifyContent={"left"}
-            variant={
-              _.includes(location.pathname, "/search") ? "solid" : "ghost"
-            }
-            leftIcon={<Icon name={"search"} />}
-            onClick={() => navigate("/search")}
-          >
-            Search
-          </Button>
+            <Button
+              leftIcon={<Icon name={"entity"} />}
+              w={"100%"}
+              justifyContent={"left"}
+              variant={
+                _.includes(location.pathname, "/entit") ? "solid" : "ghost"
+              }
+              onClick={() => navigate("/entities")}
+            >
+              <Flex w={"100%"} align={"center"} gap={"2"}>
+                <Text>Entities</Text>
+              </Flex>
+            </Button>
+            <Button
+              leftIcon={<Icon name={"attribute"} />}
+              w={"100%"}
+              justifyContent={"left"}
+              variant={
+                _.includes(location.pathname, "/attribute") ? "solid" : "ghost"
+              }
+              onClick={() => navigate("/attributes")}
+            >
+              Attributes
+            </Button>
+          </Flex>
 
           <Spacer />
         </Flex>
@@ -185,86 +180,86 @@ const Navigation = () => {
           align={"self-start"}
           w={"100%"}
         >
-          <Button
-            key={"create"}
-            w={"100%"}
-            colorScheme={"green"}
-            variant={"solid"}
-            leftIcon={<Icon name={"add"} />}
-            onClick={() => responsiveNavigate("/create")}
-          >
-            <Flex pr={"4"}>Create</Flex>
-          </Button>
+          <Flex direction={"column"} gap={"2"} width={"100%"}>
+            <Text fontSize={"xs"} fontWeight={"bold"} color={"gray.600"}>Actions</Text>
+            <Button
+              key={"create"}
+              w={"100%"}
+              colorScheme={"green"}
+              variant={"solid"}
+              leftIcon={<Icon name={"add"} />}
+              onClick={() => responsiveNavigate("/create")}
+            >
+              <Flex pr={"4"}>Create</Flex>
+            </Button>
+          </Flex>
 
-          <Divider />
+          <Flex direction={"column"} gap={"2"} width={"100%"}>
+            <Text fontSize={"xs"} fontWeight={"bold"} color={"gray.600"}>Menu</Text>
+            <Button
+              key={"dashboard"}
+              w={"100%"}
+              justifyContent={"left"}
+              variant={_.isEqual(location.pathname, "/") ? "solid" : "ghost"}
+              leftIcon={<Icon name={"dashboard"} />}
+              onClick={() => responsiveNavigate("/")}
+            >
+              Dashboard
+            </Button>
 
-          <Button
-            key={"dashboard"}
-            w={"100%"}
-            justifyContent={"left"}
-            variant={_.isEqual(location.pathname, "/") ? "solid" : "ghost"}
-            leftIcon={<Icon name={"dashboard"} />}
-            onClick={() => responsiveNavigate("/")}
-          >
-            Dashboard
-          </Button>
+            <Button
+              key={"search"}
+              w={"100%"}
+              justifyContent={"left"}
+              variant={
+                _.startsWith(location.pathname, "/search") ? "solid" : "ghost"
+              }
+              leftIcon={<Icon name={"search"} />}
+              onClick={() => responsiveNavigate("/search")}
+            >
+              Search
+            </Button>
 
-          <Divider />
+            <Button
+              leftIcon={<Icon name={"project"} />}
+              w={"100%"}
+              justifyContent={"left"}
+              variant={
+                _.startsWith(location.pathname, "/project") ? "solid" : "ghost"
+              }
+              onClick={() => responsiveNavigate("/projects")}
+            >
+              <Flex w={"100%"} align={"center"} gap={"2"}>
+                <Text>Projects</Text>
+              </Flex>
+            </Button>
 
-          <Button
-            leftIcon={<Icon name={"project"} />}
-            w={"100%"}
-            justifyContent={"left"}
-            variant={
-              _.startsWith(location.pathname, "/project") ? "solid" : "ghost"
-            }
-            onClick={() => responsiveNavigate("/projects")}
-          >
-            <Flex w={"100%"} align={"center"} gap={"2"}>
-              <Text>Projects</Text>
-            </Flex>
-          </Button>
+            <Button
+              leftIcon={<Icon name={"entity"} />}
+              w={"100%"}
+              justifyContent={"left"}
+              variant={
+                _.startsWith(location.pathname, "/entities") ? "solid" : "ghost"
+              }
+              onClick={() => responsiveNavigate("/entities")}
+            >
+              <Flex w={"100%"} align={"center"} gap={"2"}>
+                <Text>Entities</Text>
+              </Flex>
+            </Button>
 
-          <Button
-            leftIcon={<Icon name={"entity"} />}
-            w={"100%"}
-            justifyContent={"left"}
-            variant={
-              _.startsWith(location.pathname, "/entities") ? "solid" : "ghost"
-            }
-            onClick={() => responsiveNavigate("/entities")}
-          >
-            <Flex w={"100%"} align={"center"} gap={"2"}>
-              <Text>Entities</Text>
-            </Flex>
-          </Button>
-
-          <Button
-            leftIcon={<Icon name={"attribute"} />}
-            w={"100%"}
-            justifyContent={"left"}
-            variant={
-              _.startsWith(location.pathname, "/attributes") ? "solid" : "ghost"
-            }
-            onClick={() => responsiveNavigate("/attributes")}
-          >
-            Attributes
-          </Button>
-
-          <Divider />
-
-          <Button
-            key={"search"}
-            w={"100%"}
-            justifyContent={"left"}
-            variant={
-              _.startsWith(location.pathname, "/search") ? "solid" : "ghost"
-            }
-            leftIcon={<Icon name={"search"} />}
-            onClick={() => responsiveNavigate("/search")}
-          >
-            Search
-          </Button>
+            <Button
+              leftIcon={<Icon name={"attribute"} />}
+              w={"100%"}
+              justifyContent={"left"}
+              variant={
+                _.startsWith(location.pathname, "/attributes") ? "solid" : "ghost"
+              }
+              onClick={() => responsiveNavigate("/attributes")}
+            >
+              Attributes
+            </Button>
+          </Flex>
         </Flex>
       )}
 

--- a/client/src/components/Uploader/index.tsx
+++ b/client/src/components/Uploader/index.tsx
@@ -117,7 +117,7 @@ const Uploader = (props: {
                       justify={"center"}
                       border={"2px"}
                       borderStyle={"dashed"}
-                      borderColor={"gray.100"}
+                      borderColor={"gray.200"}
                       rounded={"md"}
                     >
                       {_.isEqual(file, {}) ? (

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -234,7 +234,7 @@ const Dashboard = () => {
             borderColor={"gray.200"}
           >
             {/* Projects heading */}
-            <Flex direction={"row"} align={"center"} gap={"2"}>
+            <Flex direction={"row"} align={"center"} gap={"4"}>
               <Icon name={"project"} size={"md"} />
               <Heading size={"lg"} fontWeight={"semibold"}>
                 Projects
@@ -291,7 +291,7 @@ const Dashboard = () => {
             borderColor={"gray.200"}
           >
             {/* Entities heading */}
-            <Flex direction={"row"} align={"center"} gap={"2"}>
+            <Flex direction={"row"} align={"center"} gap={"4"}>
               <Icon name={"entity"} size={"md"} />
               <Heading size={"lg"} fontWeight={"semibold"}>
                 Entities
@@ -352,7 +352,7 @@ const Dashboard = () => {
           borderColor={"gray.200"}
         >
           {/* Activity heading */}
-          <Flex align={"center"} gap={"2"} pb={"2"}>
+          <Flex align={"center"} gap={"4"}>
             <Icon name={"activity"} size={"md"} />
             <Heading size={"lg"} fontWeight={"semibold"}>
               Activity

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -8,10 +8,10 @@ import {
   Text,
   useToast,
   Spacer,
-  List,
-  ListItem,
   useBreakpoint,
   Tag,
+  VStack,
+  StackDivider,
 } from "@chakra-ui/react";
 import { createColumnHelper } from "@tanstack/react-table";
 import { Content } from "@components/Container";
@@ -230,8 +230,8 @@ const Dashboard = () => {
             background={"white"}
             rounded={"md"}
             gap={"2"}
-            border={"1px"}
-            borderColor={"gray.100"}
+            border={"2px"}
+            borderColor={"gray.200"}
           >
             {/* Projects heading */}
             <Flex direction={"row"} align={"center"} gap={"2"}>
@@ -287,8 +287,8 @@ const Dashboard = () => {
             background={"white"}
             rounded={"md"}
             gap={"2"}
-            border={"1px"}
-            borderColor={"gray.100"}
+            border={"2px"}
+            borderColor={"gray.200"}
           >
             {/* Entities heading */}
             <Flex direction={"row"} align={"center"} gap={"2"}>
@@ -348,11 +348,11 @@ const Dashboard = () => {
           gap={"2"}
           grow={"1"}
           rounded={"md"}
-          border={"1px"}
-          borderColor={"gray.100"}
+          border={"2px"}
+          borderColor={"gray.200"}
         >
           {/* Activity heading */}
-          <Flex align={"center"} gap={"2"}>
+          <Flex align={"center"} gap={"2"} pb={"2"}>
             <Icon name={"activity"} size={"md"} />
             <Heading size={"lg"} fontWeight={"semibold"}>
               Activity
@@ -361,7 +361,10 @@ const Dashboard = () => {
 
           {/* Activity list */}
           {activityData.length > 0 ? (
-            <List>
+            <VStack
+              divider={<StackDivider borderColor={"gray.200"} />}
+              spacing={"2"}
+            >
               {activityData.slice(0, 10).map((activity) => {
                 // Configure the badge
                 let operationIcon: IconNames = "entity";
@@ -383,27 +386,21 @@ const Dashboard = () => {
                 }
 
                 return (
-                  <ListItem key={`activity-${activity._id}`}>
-                    <Flex
-                      direction={"row"}
-                      p={"2"}
-                      gap={"2"}
-                      mt={"2"}
-                      mb={"2"}
-                      align={"center"}
-                      rounded={"md"}
-                      background={"white"}
-                      border={"1px"}
-                      borderColor={"gray.100"}
-                    >
-                      <Flex rounded={"full"} bg={operationIconColor} p={"1"}>
-                        <Icon
-                          size={"xs"}
-                          name={operationIcon}
-                          color={"white"}
-                        />
-                      </Flex>
+                  <Flex
+                    direction={"row"}
+                    width={"100%"}
+                    gap={"2"}
+                    key={`activity-${activity._id}`}
+                  >
+                    <Flex rounded={"full"} p={"2"} mr={"2"} alignSelf={"center"}>
+                      <Icon
+                        size={"sm"}
+                        name={operationIcon}
+                        color={operationIconColor}
+                      />
+                    </Flex>
 
+                    <Flex direction="column" align={"baseline"}>
                       <Text display={{ base: "none", sm: "block" }}>
                         {activity.details}
                       </Text>
@@ -412,18 +409,19 @@ const Dashboard = () => {
                         id={activity.target.id}
                         type={activity.target.type}
                         fallback={activity.target.name}
+                        justify={"left"}
                       />
-
-                      <Spacer />
-
-                      <Text color={"gray.400"}>
-                        {dayjs(activity.timestamp).fromNow()}
-                      </Text>
                     </Flex>
-                  </ListItem>
+
+                    <Spacer />
+
+                    <Text fontSize={"xs"} fontWeight={"semibold"} color={"gray.500"}>
+                      {dayjs(activity.timestamp).fromNow()}
+                    </Text>
+                  </Flex>
                 );
               })}
-            </List>
+            </VStack>
           ) : (
             <Flex w={"100%"} justify={"center"}>
               <Text fontSize={"md"} fontWeight={"bold"}>

--- a/client/src/pages/QueryBuilderTab.tsx
+++ b/client/src/pages/QueryBuilderTab.tsx
@@ -108,8 +108,8 @@ const QueryBuilderTab: React.FC<QueryBuilderTabProps> = ({
             direction={"column"}
             p={"2"}
             rounded={"md"}
-            border={"1px"}
-            borderColor={"gray.100"}
+            border={"2px"}
+            borderColor={"gray.200"}
           >
             <Flex direction={"row"} p={"2"} gap={"4"} wrap={"wrap"}>
               {/* Query builder components */}

--- a/client/src/pages/Search.tsx
+++ b/client/src/pages/Search.tsx
@@ -139,7 +139,7 @@ const Search = () => {
     setIsSearching(true);
     setHasSearched(true);
     setResults([]);
-  
+
     // Use the new search route for text-based search
     postData(`/entities/search/`, { query: query}) // Assuming you pass user ID for permissions filtering
       .then((results) => {
@@ -407,7 +407,7 @@ const Search = () => {
             </Flex>
           ) : (
             hasSearched && (
-              <Flex direction={"column"} w={"100%"}>
+              <Flex direction={"column"} w={"100%"} gap={"4"}>
                 <Heading size={"md"} fontWeight={"semibold"}>
                   {results.length} search result
                   {results.length > 1 || results.length === 0 ? "s" : ""}

--- a/client/src/pages/create/Create.tsx
+++ b/client/src/pages/create/Create.tsx
@@ -39,7 +39,7 @@ const Create = () => {
         wrap={"wrap"}
       >
         {/* Project card */}
-        <Card maxW={"sm"} h={"lg"} variant={"outline"}>
+        <Card maxW={"sm"} h={"lg"} variant={"outline"} border={"2px"} borderColor={"gray.200"}>
           <CardHeader>
             <Flex gap={"4"} w={"100%"} justify={"center"} align={"center"}>
               <Icon name={"project"} size={"lg"} />
@@ -48,17 +48,20 @@ const Create = () => {
           </CardHeader>
           <CardBody>
             <Stack divider={<StackDivider />} spacing={"2"}>
-              <Flex p={"2"} gap={"4"} align={"center"} direction={"column"}>
+              <Flex p={"2"} gap={"4"} direction={"column"}>
                 <Heading size={"xs"} textTransform={"uppercase"}>
                   Description
                 </Heading>
                 <Text>Create a Project to organize and share Entities.</Text>
               </Flex>
-              <Flex p={"2"} gap={"4"} align={"center"} direction={"column"}>
+              <Flex p={"2"} gap={"4"} direction={"column"}>
                 <Heading size={"xs"} textTransform={"uppercase"}>
                   Fields
                 </Heading>
-                <Flex gap={"2"}>
+                <Flex align={"center"} wrap={"wrap"} gap={"2"}>
+                  <Text fontSize={"xs"} fontWeight={"semibold"} color={"gray.600"}>
+                    Required
+                  </Text>
                   <Tag colorScheme={"red"}>Name</Tag>
                   <Tag colorScheme={"red"}>Description</Tag>
                 </Flex>
@@ -79,7 +82,7 @@ const Create = () => {
         </Card>
 
         {/* Entity card */}
-        <Card maxW={"sm"} h={"lg"} variant={"outline"}>
+        <Card maxW={"sm"} h={"lg"} variant={"outline"} border={"2px"} borderColor={"gray.200"}>
           <CardHeader>
             <Flex gap={"4"} w={"100%"} justify={"center"} align={"center"}>
               <Icon name={"entity"} size={"lg"} />
@@ -88,22 +91,31 @@ const Create = () => {
           </CardHeader>
           <CardBody>
             <Stack divider={<StackDivider />} spacing={"2"}>
-              <Flex p={"2"} gap={"4"} align={"center"} direction={"column"}>
+              <Flex p={"2"} gap={"4"} direction={"column"}>
                 <Heading size={"xs"} textTransform={"uppercase"}>
                   Description
                 </Heading>
                 <Text>
-                  Create an Entity to group metadata about a physical or digital
+                  Create an Entity to store metadata of a physical or digital
                   resource.
                 </Text>
               </Flex>
-              <Flex p={"2"} gap={"4"} align={"center"} direction={"column"}>
+              <Flex p={"2"} gap={"4"} direction={"column"}>
                 <Heading size={"xs"} textTransform={"uppercase"}>
                   Fields
                 </Heading>
-                <Flex gap={"2"} wrap={"wrap"}>
+                <Flex align={"center"} wrap={"wrap"} gap={"2"}>
+                  <Text fontSize={"xs"} fontWeight={"semibold"} color={"gray.600"}>
+                    Required
+                  </Text>
                   <Tag colorScheme={"red"}>Name</Tag>
                   <Tag colorScheme={"red"}>Created</Tag>
+                </Flex>
+
+                <Flex align={"center"} wrap={"wrap"} gap={"2"}>
+                  <Text fontSize={"xs"} fontWeight={"semibold"} color={"gray.600"}>
+                    Optional
+                  </Text>
                   <Tag colorScheme={"teal"}>Description</Tag>
                   <Tag colorScheme={"teal"}>Projects</Tag>
                   <Tag colorScheme={"teal"}>Origins</Tag>
@@ -127,7 +139,7 @@ const Create = () => {
         </Card>
 
         {/* Attribute card */}
-        <Card maxW={"sm"} h={"lg"} variant={"outline"}>
+        <Card maxW={"sm"} h={"lg"} variant={"outline"} border={"2px"} borderColor={"gray.200"}>
           <CardHeader>
             <Flex gap={"4"} w={"100%"} justify={"center"} align={"center"}>
               <Icon name={"attribute"} size={"lg"} />
@@ -136,20 +148,22 @@ const Create = () => {
           </CardHeader>
           <CardBody>
             <Stack divider={<StackDivider />} spacing={"2"}>
-              <Flex p={"2"} gap={"4"} align={"center"} direction={"column"}>
+              <Flex p={"2"} gap={"4"} direction={"column"}>
                 <Heading size={"xs"} textTransform={"uppercase"}>
                   Description
                 </Heading>
                 <Text>
-                  Create a template Attribute to standardize reusable components
-                  of metadata to be associated with Entities.
+                  Create template Attributes to reuse metadata structures across Entities.
                 </Text>
               </Flex>
-              <Flex p={"2"} gap={"4"} align={"center"} direction={"column"}>
+              <Flex p={"2"} gap={"4"} direction={"column"}>
                 <Heading size={"xs"} textTransform={"uppercase"}>
                   Fields
                 </Heading>
-                <Flex gap={"2"} wrap={"wrap"}>
+                <Flex align={"center"} wrap={"wrap"} gap={"2"}>
+                  <Text fontSize={"xs"} fontWeight={"semibold"} color={"gray.600"}>
+                    Required
+                  </Text>
                   <Tag colorScheme={"red"}>Name</Tag>
                   <Tag colorScheme={"red"}>Description</Tag>
                   <Tag colorScheme={"red"}>Values</Tag>

--- a/client/src/pages/create/Entity.tsx
+++ b/client/src/pages/create/Entity.tsx
@@ -341,7 +341,7 @@ const Entity = () => {
         {_.isEqual("start", pageState) && (
           <Flex direction={"column"} gap={"2"} grow={"1"}>
             <FormControl isRequired isInvalid={isNameError || !isNameUnique}>
-              <FormLabel>Entity Name</FormLabel>
+              <FormLabel>Name</FormLabel>
               <Input
                 name={"name"}
                 value={name}
@@ -376,7 +376,7 @@ const Entity = () => {
             </FormControl>
 
             <FormControl>
-              <FormLabel>Entity Description</FormLabel>
+              <FormLabel>Description</FormLabel>
               <Textarea
                 value={description}
                 placeholder={"Description"}
@@ -401,11 +401,11 @@ const Entity = () => {
                 p={"2"}
                 direction={"column"}
                 rounded={"md"}
-                border={"1px"}
-                borderColor={"gray.100"}
+                border={"2px"}
+                borderColor={"gray.200"}
               >
                 <FormControl>
-                  <FormLabel>Origin Entities</FormLabel>
+                  <FormLabel>Origins</FormLabel>
                   <Select
                     title="Select Entity"
                     placeholder={"Select Entity"}
@@ -490,11 +490,11 @@ const Entity = () => {
                 p={"2"}
                 direction={"column"}
                 rounded={"md"}
-                border={"1px"}
-                borderColor={"gray.100"}
+                border={"2px"}
+                borderColor={"gray.200"}
               >
                 <FormControl>
-                  <FormLabel>Product Entities</FormLabel>
+                  <FormLabel>Products</FormLabel>
                   <Select
                     title="Select Entity"
                     placeholder={"Select Entity"}
@@ -580,8 +580,8 @@ const Entity = () => {
               p={"2"}
               direction={"column"}
               rounded={"md"}
-              border={"1px"}
-              borderColor={"gray.100"}
+              border={"2px"}
+              borderColor={"gray.200"}
             >
               <FormControl>
                 <FormLabel>Projects</FormLabel>
@@ -606,7 +606,7 @@ const Entity = () => {
                 </CheckboxGroup>
                 <FormHelperText>
                   Specify the Projects that this new Entity should be included
-                  with. The Entity will then show up underneath the specified
+                  with. The Entity will then be contained within the specified
                   Projects.
                 </FormHelperText>
               </FormControl>

--- a/client/src/pages/view/Attribute.tsx
+++ b/client/src/pages/view/Attribute.tsx
@@ -260,8 +260,8 @@ const Attribute = () => {
             basis={"50%"}
             h={"fit-content"}
             rounded={"md"}
-            border={"1px"}
-            borderColor={"gray.100"}
+            border={"2px"}
+            borderColor={"gray.200"}
           >
             <Heading fontWeight={"semibold"} size={"md"}>
               Values

--- a/client/src/pages/view/Entity.tsx
+++ b/client/src/pages/view/Entity.tsx
@@ -1312,7 +1312,7 @@ const Entity = () => {
             <Flex direction={"column"} p={"4"} bg={"gray.50"} rounded={"md"}>
               <Flex gap={"4"} direction={"column"}>
                 <Heading fontWeight={"semibold"} size={"md"} pt={"2"} pb={"2"}>
-                  Entity Overview
+                  Overview
                 </Heading>
                 <Flex gap={"2"} direction={"row"}>
                   {/* "Created" and "Owner" fields */}
@@ -1352,8 +1352,8 @@ const Entity = () => {
               direction={"column"}
               p={"4"}
               rounded={"md"}
-              border={"1px"}
-              borderColor={"gray.100"}
+              border={"2px"}
+              borderColor={"gray.200"}
             >
               <Flex
                 direction={"row"}
@@ -1361,7 +1361,7 @@ const Entity = () => {
                 align={"center"}
               >
                 <Heading fontWeight={"semibold"} size={"md"} pt={"2"} pb={"2"}>
-                  Entity Projects
+                  Projects
                 </Heading>
                 {editing ? (
                   <Button
@@ -1404,8 +1404,8 @@ const Entity = () => {
               direction={"column"}
               p={"4"}
               rounded={"md"}
-              border={"1px"}
-              borderColor={"gray.100"}
+              border={"2px"}
+              borderColor={"gray.200"}
             >
               <Flex
                 direction={"row"}
@@ -1413,7 +1413,7 @@ const Entity = () => {
                 align={"center"}
               >
                 <Heading fontWeight={"semibold"} size={"md"} pt={"2"} pb={"2"}>
-                  Entity Attributes
+                  Attributes
                 </Heading>
                 {editing ? (
                   <Button
@@ -1458,8 +1458,8 @@ const Entity = () => {
               direction={"column"}
               p={"4"}
               rounded={"md"}
-              border={"1px"}
-              borderColor={"gray.100"}
+              border={"2px"}
+              borderColor={"gray.200"}
             >
               <Tabs
                 variant={"soft-rounded"}
@@ -1467,8 +1467,8 @@ const Entity = () => {
                 onChange={(index) => setRelationsIndex(index)}
               >
                 <TabList>
-                  <Tab>Entity Origins</Tab>
-                  <Tab>Entity Products</Tab>
+                  <Tab>Origins</Tab>
+                  <Tab>Products</Tab>
                   <Spacer />
                   {editing ? (
                     <Button
@@ -1535,8 +1535,8 @@ const Entity = () => {
               direction={"column"}
               p={"4"}
               rounded={"md"}
-              border={"1px"}
-              borderColor={"gray.100"}
+              border={"2px"}
+              borderColor={"gray.200"}
             >
               <Flex gap={"2"} direction={"column"} minH={"32"}>
                 <Flex

--- a/client/src/pages/view/Project.tsx
+++ b/client/src/pages/view/Project.tsx
@@ -628,8 +628,8 @@ const Project = () => {
               h={"fit-content"}
               grow={"1"}
               rounded={"md"}
-              border={"1px"}
-              borderColor={"gray.100"}
+              border={"2px"}
+              borderColor={"gray.200"}
             >
               <Flex
                 direction={"row"}

--- a/cypress/e2e/1_launch.spec.cy.ts
+++ b/cypress/e2e/1_launch.spec.cy.ts
@@ -1,8 +1,7 @@
 describe('checking app does launch ', () => {
-  it('checking Project and Entities box', () => {
+  it('checking Search and Projects box', () => {
     cy.visit('http://localhost:8080/');
-    cy.get(':nth-child(1) > .css-r4opcp > .chakra-heading').should('have.text', 'Projects');
-    cy.get(':nth-child(2) > .css-r4opcp > .chakra-heading').should('have.text', 'Entities');
+    cy.get('.css-50hugx > :nth-child(2) > button:nth-child(3)').should('have.text', 'Search');
+    cy.get('.css-50hugx > :nth-child(2) > button:nth-child(4)').should('have.text', 'Projects');
   })
-  
-})
+});

--- a/cypress/e2e/3_query_builder.spec.cy.ts
+++ b/cypress/e2e/3_query_builder.spec.cy.ts
@@ -12,6 +12,6 @@ describe('search query builder', () => {
     // press search button
     cy.get('[aria-label="Search Query"]').click();
     // result array should exist
-    cy.get('.css-1ofqig9 > .chakra-heading').should('contain.text', 'search results');
+    cy.get('.css-aybym5 > .chakra-heading').should('contain.text', 'search results');
   });
 });

--- a/cypress/e2e/4_entity_edit_attribute.spec.cy.ts
+++ b/cypress/e2e/4_entity_edit_attribute.spec.cy.ts
@@ -9,7 +9,7 @@ describe('In entity page, edit attribute', () => {
     cy.contains('button', 'Edit').click();
 
     // add attribute
-    cy.get(':nth-child(2) > .css-sdf56e > .css-1ialerq > .chakra-button').click();
+    cy.get(':nth-child(2) > .css-1acctax > .css-1ialerq > .chakra-button').click();
     cy.get('#formName').type('Attribute Name');
     cy.get('#formDescription').type('Attribute Description');
     cy.get('.add-value-button-form').click();
@@ -22,7 +22,7 @@ describe('In entity page, edit attribute', () => {
 
     cy.get('.chakra-modal__body')
     .get('button').eq(-1).click();
-    
+
     cy.contains('button', 'Done').click();
 
     cy.contains('No Attributes.').should('not.exist');
@@ -39,6 +39,5 @@ describe('In entity page, edit attribute', () => {
     cy.contains('No Attributes.').should('exist');
     cy.reload();
     cy.contains('No Attributes.').should('exist');
-
   });
 });

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -98,6 +98,7 @@ export type LinkyProps = {
   id: string;
   fallback?: string;
   color?: string;
+  justify?: string;
 };
 
 // Project types


### PR DESCRIPTION
## Description

* Added colour gradient background to left navigation menu
* Updated grouping of menu items
* Changed most UI borders to `2px` `gray.200` borders
* Increased spacing of some small UI components
* Added optional `Linky` prop `justify`, allowing options other than `center` to be specified

## Ticket

https://dev.azure.com/gt-sse-center/MARS%202023/_workitems/edit/299/

## Demo 🎥

Please provide any images, GIFs, or videos that show the effect of your changes (if applicable). A picture is worth a thousand words.


