### PR TITLE
[MARS 310] Small UI updates for appearance

### DIFF
--- a/client/src/components/DataTable/index.tsx
+++ b/client/src/components/DataTable/index.tsx
@@ -127,8 +127,19 @@ const DataTable = (props: DataTableProps) => {
     setColumnVisibility(props.visibleColumns);
   }, [props.visibleColumns]);
 
+  // Exclude columns that are not sortable, i.e. checkboxes and buttons
+  const canSortColumn = (header: any) => {
+    return !_.isEqual(header.id, "select") && !_.isEqual(header.id, "_id");
+  };
+
+  // Utility function to get sorting handlers with correct behaviour
+  const getToggleSortingHandler = (header: any) => {
+    if (!canSortColumn(header)) return;
+    return header.column.getToggleSortingHandler();
+  };
+
   return (
-    <Flex direction={"column"}>
+    <Flex w={"100%"} direction={"column"}>
       <TableContainer>
         <Table variant={"simple"} size={"sm"}>
           {/* Table head */}
@@ -140,21 +151,26 @@ const DataTable = (props: DataTableProps) => {
                   return (
                     <Th
                       key={header.id}
-                      onClick={header.column.getToggleSortingHandler()}
+                      onClick={getToggleSortingHandler(header)}
                       isNumeric={meta?.isNumeric}
                       // Dynamically set the width for the checkboxes
                       w={_.isEqual(header.id, "select") ? "1" : "auto"}
-                      _hover={{ cursor: 'pointer', background: "blue.50" }}
-                      transition="background-color 0.3s ease-in-out, color 0.3s ease-in-out"
+                      _hover={canSortColumn(header) ? { cursor: "pointer", background: "gray.100" } : {}}
+                      transition={canSortColumn(header) ? "background-color 0.3s ease-in-out, color 0.3s ease-in-out" : ""}
                     >
                       {flexRender(
                         header.column.columnDef.header,
                         header.getContext()
                       )}
-                      <Icon
-                        name={(header.column.getIsSorted() === 'desc' ? 'c_down' : 'c_up')}
-                        style={{ marginLeft: '4px', }}
-                      />
+                      {canSortColumn(header) &&
+                        <Icon
+                          name={
+                            (header.column.getIsSorted() === "desc" ? "sort_up" :
+                              (header.column.getIsSorted() === "asc" ? "sort_down" : "sort"))
+                          }
+                          style={{ marginLeft: '4px', }}
+                        />
+                      }
                     </Th>
                   );
                 })}

--- a/client/src/components/DataTable/index.tsx
+++ b/client/src/components/DataTable/index.tsx
@@ -129,7 +129,7 @@ const DataTable = (props: DataTableProps) => {
 
   // Exclude columns that are not sortable, i.e. checkboxes and buttons
   const canSortColumn = (header: any) => {
-    return !_.isEqual(header.id, "select") && !_.isEqual(header.id, "_id");
+    return !_.isEqual(header.id, "select") && !_.isEqual(header.id, "_id") && !_.isEqual(header.id, "view");
   };
 
   // Utility function to get sorting handlers with correct behaviour

--- a/client/src/components/Icon/index.tsx
+++ b/client/src/components/Icon/index.tsx
@@ -53,6 +53,7 @@ import {
 } from "react-icons/bs";
 import { SiBox } from "react-icons/si";
 import { SlGraph } from "react-icons/sl";
+import { FaSort, FaSortDown, FaSortUp } from "react-icons/fa";
 
 // Existing and custom types
 import { IconNames } from "@types";
@@ -124,6 +125,11 @@ const SYSTEM_ICONS: { [k: string]: IconType } = {
   c_double_right: BsChevronDoubleRight,
   c_up: BsChevronUp,
   c_down: BsChevronDown,
+
+  // Sort
+  sort: FaSort,
+  sort_up: FaSortUp,
+  sort_down: FaSortDown,
 };
 
 const Icon = (props: {

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -259,7 +259,7 @@ const Dashboard = () => {
                 justify={"center"}
                 align={"center"}
               >
-                <Text fontWeight={"bold"}>No Projects yet</Text>
+                <Text color={"gray.400"} fontWeight={"semibold"}>You do not have any Projects.</Text>
               </Flex>
             )}
 
@@ -318,7 +318,7 @@ const Dashboard = () => {
                 justify={"center"}
                 align={"center"}
               >
-                <Text fontWeight={"bold"}>No Entities yet</Text>
+                <Text color={"gray.400"} fontWeight={"semibold"}>You do not have any Entities.</Text>
               </Flex>
             )}
 
@@ -427,9 +427,7 @@ const Dashboard = () => {
             </Flex>
           ) : (
             <Flex w={"100%"} h={"100%"} justify={"center"} align={"center"}>
-              <Text fontSize={"md"} fontWeight={"bold"}>
-                No Activity yet
-              </Text>
+              <Text color={"gray.400"} fontWeight={"semibold"}>No Activity yet.</Text>
             </Flex>
           )}
         </Flex>

--- a/client/src/pages/QueryBuilderTab.tsx
+++ b/client/src/pages/QueryBuilderTab.tsx
@@ -93,6 +93,7 @@ const QueryBuilderTab: React.FC<QueryBuilderTabProps> = ({
         />
         <Flex direction={"row"} w={"100%"} gap={"4"} justify={"right"} mt={2}>
           <Button
+            aria-label={"Run Query"}
             colorScheme={"green"}
             rightIcon={<Icon name={"search"} />}
             onClick={() => onSearchBuiltQuery()}

--- a/client/src/pages/QueryBuilderTab.tsx
+++ b/client/src/pages/QueryBuilderTab.tsx
@@ -1,5 +1,5 @@
 
-import { TabPanel, Flex, FormControl, FormLabel, Select, Input, Spacer, IconButton, VStack, Tag, Button, useToast } from '@chakra-ui/react';
+import { TabPanel, Flex, FormControl, FormLabel, Select, Input, Spacer, IconButton, VStack, Tag, Button, useToast, Box } from '@chakra-ui/react';
 import { QueryFocusType, QueryParameters, QueryQualifier, QuerySubQualifier, QueryOperator, EntityModel } from '@types';
 import Icon from "@components/Icon";
 import QueryBuilder, { formatQuery } from 'react-querybuilder';
@@ -55,7 +55,6 @@ const QueryBuilderTab: React.FC<QueryBuilderTabProps> = ({
 
   const toast = useToast();
 
-
   // Function to handle query changes
   const onQueryChange = (q: any) => {
     setQuery(formatQuery(q, 'mongodb'));
@@ -86,22 +85,23 @@ const QueryBuilderTab: React.FC<QueryBuilderTabProps> = ({
 
   return (
     <TabPanel>
-      <div>
+      <Box>
         <QueryBuilder
           fields={fields}
           onQueryChange={onQueryChange}
-
-        // You can add more props as needed
+          // You can add more props as needed
         />
         <Flex direction={"row"} w={"100%"} gap={"4"} justify={"right"} mt={2}>
-          <IconButton
-            aria-label={"Search Query"}
+          <Button
             colorScheme={"green"}
-            icon={<Icon name={"search"} />}
+            rightIcon={<Icon name={"search"} />}
             onClick={() => onSearchBuiltQuery()}
-          />
+            isDisabled={_.isEqual(query, {})}
+          >
+            Run Query
+          </Button>
         </Flex>
-      </div>
+      </Box>
       {false && /* disableled Legacy Query builder components */
         <Flex w={"100%"} direction={"column"} gap={"4"}>
           <Flex

--- a/client/src/pages/view/Attribute.tsx
+++ b/client/src/pages/view/Attribute.tsx
@@ -220,16 +220,19 @@ const Attribute = () => {
             p={"4"}
             h={"fit-content"}
             grow={"1"}
-            basis={"40%"}
+            width={"30%"}
             bg={"gray.50"}
             rounded={"md"}
           >
-            {/* Project Overview */}
-            <Flex gap={"4"} grow={"1"} direction={"column"} minH={"32"}>
+            {/* Attribute Overview */}
+            <Flex gap={"2"} grow={"1"} direction={"column"} minH={"32"}>
               {/* Details */}
-              <Heading fontWeight={"semibold"} size={"md"}>
-                Template Details
-              </Heading>
+              <Text fontWeight={"semibold"}>Owner</Text>
+              <Flex>
+                <Tag colorScheme={"green"}>
+                  <TagLabel>{attributeData.owner}</TagLabel>
+                </Tag>
+              </Flex>
               <Text fontWeight={"semibold"}>Description</Text>
               {_.isEqual(attributeData.description, "") ? (
                 <Tag
@@ -247,6 +250,9 @@ const Attribute = () => {
                     setAttributeDescription(event.target.value);
                   }}
                   isReadOnly={!editing}
+                  bg={"white"}
+                  border={"2px"}
+                  borderColor={"gray.200"}
                 />
               )}
             </Flex>
@@ -257,7 +263,7 @@ const Attribute = () => {
             p={"4"}
             gap={"2"}
             grow={"1"}
-            basis={"50%"}
+            width={"65%"}
             h={"fit-content"}
             rounded={"md"}
             border={"2px"}

--- a/client/src/pages/view/Attributes.tsx
+++ b/client/src/pages/view/Attributes.tsx
@@ -7,6 +7,7 @@ import {
   Flex,
   Heading,
   Spacer,
+  Text,
   useBreakpoint,
   useToast,
 } from "@chakra-ui/react";
@@ -142,12 +143,24 @@ const Attributes = () => {
           </Button>
         </Flex>
         <Flex direction={"column"} gap={"4"} w={"100%"}>
-          <DataTable
-            columns={columns}
-            data={data}
-            visibleColumns={visibleColumns}
-            showPagination
-          />
+          {data.length > 0 ?
+            <DataTable
+              columns={columns}
+              data={data}
+              visibleColumns={visibleColumns}
+              showPagination
+            />
+          :
+            <Flex
+              w={"100%"}
+              direction={"row"}
+              p={"4"}
+              justify={"center"}
+              align={"center"}
+            >
+              <Text color={"gray.400"} fontWeight={"semibold"}>You do not have any Templates.</Text>
+            </Flex>
+          }
         </Flex>
       </Flex>
     </Content>

--- a/client/src/pages/view/Entities.tsx
+++ b/client/src/pages/view/Entities.tsx
@@ -236,14 +236,26 @@ const Entities = () => {
           </Flex>
         </Flex>
         <Flex direction={"column"} gap={"4"} w={"100%"}>
-          <DataTable
-            columns={columns}
-            data={data.filter((entity) => _.isEqual(entity.deleted, false))}
-            visibleColumns={visibleColumns}
-            actions={actions}
-            showSelection
-            showPagination
-          />
+          {data.filter((entity) => _.isEqual(entity.deleted, false)).length > 0 ?
+            <DataTable
+              columns={columns}
+              data={data.filter((entity) => _.isEqual(entity.deleted, false))}
+              visibleColumns={visibleColumns}
+              actions={actions}
+              showSelection
+              showPagination
+            />
+          :
+            <Flex
+              w={"100%"}
+              direction={"row"}
+              p={"4"}
+              justify={"center"}
+              align={"center"}
+            >
+              <Text color={"gray.400"} fontWeight={"semibold"}>You do not have any Entities.</Text>
+            </Flex>
+          }
         </Flex>
       </Flex>
     </Content>

--- a/client/src/pages/view/Entity.tsx
+++ b/client/src/pages/view/Entity.tsx
@@ -1312,14 +1312,12 @@ const Entity = () => {
             {/* Entity Overview */}
             <Flex direction={"column"} p={"4"} bg={"gray.50"} rounded={"md"}>
               <Flex gap={"4"} direction={"column"}>
-                <Heading fontWeight={"semibold"} size={"md"} pt={"2"} pb={"2"}>
-                  Overview
-                </Heading>
                 <Flex gap={"2"} direction={"row"}>
                   {/* "Created" and "Owner" fields */}
                   <Flex gap={"2"} direction={"column"} basis={"40%"}>
                     <Text fontWeight={"semibold"}>Created</Text>
-                    <Flex>
+                    <Flex align={"center"} gap={"2"}>
+                      <Icon name={"v_date"} size={"sm"} />
                       <Text>
                         {dayjs(entityData.created).format("DD MMM YYYY")}
                       </Text>
@@ -1341,6 +1339,9 @@ const Entity = () => {
                           setEntityDescription(event.target.value || "");
                         }}
                         isReadOnly={!editing}
+                        border={"2px"}
+                        borderColor={"gray.200"}
+                        bg={"white"}
                       />
                     </Flex>
                   </Flex>
@@ -1361,7 +1362,7 @@ const Entity = () => {
                 justify={"space-between"}
                 align={"center"}
               >
-                <Heading fontWeight={"semibold"} size={"md"} pt={"2"} pb={"2"}>
+                <Heading fontWeight={"semibold"} size={"md"} py={"2"}>
                   Projects
                 </Heading>
                 {editing ? (
@@ -1375,20 +1376,21 @@ const Entity = () => {
                   </Button>
                 ) : null}
               </Flex>
-
-              {entityProjects.length === 0 ? (
-                <Text>No Projects.</Text>
-              ) : (
-                <DataTable
-                  data={entityProjects}
-                  columns={projectsTableColumns}
-                  visibleColumns={{}}
-                  viewOnly={!editing}
-                  showSelection={editing}
-                  actions={projectsTableActions}
-                  showPagination
-                />
-              )}
+              <Flex w={"100%"} justify={"center"} align={"center"} minH={"100px"}>
+                {entityProjects.length === 0 ? (
+                  <Text color={"gray.400"} fontWeight={"semibold"}>This Entity is not associated with any Projects.</Text>
+                ) : (
+                  <DataTable
+                    data={entityProjects}
+                    columns={projectsTableColumns}
+                    visibleColumns={{}}
+                    viewOnly={!editing}
+                    showSelection={editing}
+                    actions={projectsTableActions}
+                    showPagination
+                  />
+                )}
+              </Flex>
             </Flex>
           </Flex>
 
@@ -1413,7 +1415,7 @@ const Entity = () => {
                 justify={"space-between"}
                 align={"center"}
               >
-                <Heading fontWeight={"semibold"} size={"md"} pt={"2"} pb={"2"}>
+                <Heading fontWeight={"semibold"} size={"md"} py={"2"}>
                   Attributes
                 </Heading>
                 {editing ? (
@@ -1428,18 +1430,20 @@ const Entity = () => {
                 ) : null}
               </Flex>
 
-              {entityAttributes.length === 0 ? (
-                <Text>No Attributes.</Text>
-              ) : (
-                <DataTable
-                  data={entityAttributes}
-                  columns={attributeTableColumns}
-                  visibleColumns={visibleAttributeTableColumns}
-                  viewOnly={!editing}
-                  showSelection={editing}
-                  showPagination
-                />
-              )}
+              <Flex w={"100%"} justify={"center"} align={"center"} minH={"100px"}>
+                {entityAttributes.length === 0 ? (
+                  <Text color={"gray.400"} fontWeight={"semibold"}>This Entity does not have any Attributes.</Text>
+                ) : (
+                  <DataTable
+                    data={entityAttributes}
+                    columns={attributeTableColumns}
+                    visibleColumns={visibleAttributeTableColumns}
+                    viewOnly={!editing}
+                    showSelection={editing}
+                    showPagination
+                  />
+                )}
+              </Flex>
             </Flex>
           </Flex>
         </Flex>
@@ -1488,8 +1492,9 @@ const Entity = () => {
                 </TabList>
                 <TabPanels>
                   <TabPanel>
+                  <Flex w={"100%"} justify={"center"} align={"center"} minH={"100px"}>
                     {(entityOrigins?.length ?? 0) === 0 ? (
-                      <Text>No Origins.</Text>
+                      <Text color={"gray.400"} fontWeight={"semibold"}>This Entity does not have any Origins.</Text>
                     ) : (
                       <DataTable
                         data={entityOrigins}
@@ -1501,21 +1506,24 @@ const Entity = () => {
                         showPagination
                       />
                     )}
+                    </Flex>
                   </TabPanel>
                   <TabPanel>
-                    {(entityProducts?.length ?? 0) === 0 ? (
-                      <Text>No Products.</Text>
-                    ) : (
-                      <DataTable
-                        data={entityProducts}
-                        columns={productTableColumns}
-                        visibleColumns={{}}
-                        viewOnly={!editing}
-                        showSelection={editing}
-                        actions={productTableActions}
-                        showPagination
-                      />
-                    )}
+                    <Flex w={"100%"} justify={"center"} align={"center"} minH={"100px"}>
+                      {(entityProducts?.length ?? 0) === 0 ? (
+                        <Text color={"gray.400"} fontWeight={"semibold"}>This Entity does not have any Products.</Text>
+                      ) : (
+                        <DataTable
+                          data={entityProducts}
+                          columns={productTableColumns}
+                          visibleColumns={{}}
+                          viewOnly={!editing}
+                          showSelection={editing}
+                          actions={productTableActions}
+                          showPagination
+                        />
+                      )}
+                    </Flex>
                   </TabPanel>
                 </TabPanels>
               </Tabs>
@@ -1548,8 +1556,7 @@ const Entity = () => {
                   <Heading
                     fontWeight={"semibold"}
                     size={"md"}
-                    pt={"2"}
-                    pb={"2"}
+                    py={"2"}
                   >
                     Attachments
                   </Heading>
@@ -1562,19 +1569,21 @@ const Entity = () => {
                   </Button>
                 </Flex>
 
-                {entityAttachments.length === 0 ? (
-                  <Text>No Attachments.</Text>
-                ) : (
-                  <DataTable
-                    data={entityAttachments}
-                    columns={attachmentTableColumns}
-                    visibleColumns={{}}
-                    viewOnly={!editing}
-                    showSelection={editing}
-                    actions={attachmentTableActions}
-                    showPagination
-                  />
-                )}
+                <Flex w={"100%"} justify={"center"} align={"center"} minH={"100px"}>
+                  {entityAttachments.length === 0 ? (
+                    <Text color={"gray.400"} fontWeight={"semibold"}>This Entity does not have any Attachments.</Text>
+                  ) : (
+                    <DataTable
+                      data={entityAttachments}
+                      columns={attachmentTableColumns}
+                      visibleColumns={{}}
+                      viewOnly={!editing}
+                      showSelection={editing}
+                      actions={attachmentTableActions}
+                      showPagination
+                    />
+                  )}
+                </Flex>
               </Flex>
             </Flex>
           </Flex>

--- a/client/src/pages/view/Project.tsx
+++ b/client/src/pages/view/Project.tsx
@@ -47,6 +47,7 @@ import {
   TagLabel,
   Text,
   Textarea,
+  Tooltip,
   VStack,
   useDisclosure,
   useToast,
@@ -557,18 +558,24 @@ const Project = () => {
                   History
                 </MenuItem>
                 {/* disabled project export as this feature is not ready yet */}
-                <MenuItem
-                  onClick={handleExportClick}
-                  icon={<Icon name={"download"} />}
-                >
-                  Export
-                </MenuItem>
-                <MenuItem
-                  onClick={handleExportJsonClick}
-                  icon={<Icon name={"download"} />}
-                >
-                  Export Project Entities Json
-                </MenuItem>
+                <Tooltip label={"Feature Disabled"}>
+                  <MenuItem
+                    onClick={handleExportClick}
+                    icon={<Icon name={"download"} />}
+                    isDisabled
+                  >
+                    Export
+                  </MenuItem>
+                </Tooltip>
+                <Tooltip isDisabled={projectEntities.length > 0} label={"This Project does not contain any Entities."}>
+                  <MenuItem
+                    onClick={handleExportJsonClick}
+                    icon={<Icon name={"download"} />}
+                    isDisabled={projectEntities.length === 0}
+                  >
+                    Export Entities (JSON)
+                  </MenuItem>
+                </Tooltip>
               </MenuList>
             </Menu>
           </Flex>

--- a/client/src/pages/view/Project.tsx
+++ b/client/src/pages/view/Project.tsx
@@ -582,12 +582,15 @@ const Project = () => {
             >
               {/* Project Overview */}
               <Flex gap={"4"} grow={"1"} direction={"column"} minH={"32"}>
-                <Heading fontWeight={"semibold"} size={"md"} pt={"2"} pb={"2"}>
-                  Project Overview
-                </Heading>
-
                 <Flex gap={"2"} direction={"row"}>
                   <Flex gap={"2"} direction={"column"} basis={"40%"}>
+                    <Text fontWeight={"semibold"}>Created</Text>
+                    <Flex align={"center"} gap={"2"}>
+                      <Icon name={"v_date"} size={"sm"} />
+                      <Text>
+                        {dayjs(projectData.created).format("DD MMM YYYY")}
+                      </Text>
+                    </Flex>
                     <Text fontWeight={"semibold"}>Owner</Text>
                     <Flex>
                       <Tag colorScheme={"green"}>
@@ -604,6 +607,9 @@ const Project = () => {
                         setProjectDescription(event.target.value);
                       }}
                       isReadOnly={!editing}
+                      bg={"white"}
+                      border={"2px"}
+                      borderColor={"gray.200"}
                     />
                   </Flex>
                 </Flex>
@@ -638,15 +644,15 @@ const Project = () => {
               >
                 {/* Entities in the Project */}
                 <Heading fontWeight={"semibold"} size={"md"} pt={"2"} pb={"2"}>
-                  Project Entities
+                  Entities
                 </Heading>
                 {editing && (
                   <Button
-                    leftIcon={<Icon name={"add"} />}
+                    rightIcon={<Icon name={"add"} />}
                     onClick={onEntitiesOpen}
                     colorScheme={"green"}
                   >
-                    Add Entity
+                    Add
                   </Button>
                 )}
               </Flex>
@@ -662,7 +668,9 @@ const Project = () => {
                     showPagination
                   />
                 ) : (
-                  <Text>This Project does not contain any Entities.</Text>
+                  <Flex w={"100%"} justify={"center"} align={"center"} minH={"100px"}>
+                    <Text color={"gray.400"} fontWeight={"semibold"}>This Project does not contain any Entities.</Text>
+                  </Flex>
                 )}
               </Flex>
             </Flex>

--- a/client/src/pages/view/Projects.tsx
+++ b/client/src/pages/view/Projects.tsx
@@ -6,6 +6,7 @@ import {
   Heading,
   Spacer,
   Tag,
+  Text,
   useBreakpoint,
   useToast,
 } from "@chakra-ui/react";
@@ -149,12 +150,24 @@ const Projects = () => {
           </Flex>
         </Flex>
         <Flex direction={"column"} gap={"4"} w={"100%"}>
-          <DataTable
-            columns={columns}
-            data={data}
-            visibleColumns={visibleColumns}
-            showPagination
-          />
+          {data.length > 0 ?
+            <DataTable
+              columns={columns}
+              data={data}
+              visibleColumns={visibleColumns}
+              showPagination
+            />
+          :
+            <Flex
+              w={"100%"}
+              direction={"row"}
+              p={"4"}
+              justify={"center"}
+              align={"center"}
+            >
+              <Text color={"gray.400"} fontWeight={"semibold"}>You do not have any Projects.</Text>
+            </Flex>
+          }
         </Flex>
       </Flex>
     </Content>

--- a/cypress/e2e/3_query_builder.spec.cy.ts
+++ b/cypress/e2e/3_query_builder.spec.cy.ts
@@ -10,7 +10,7 @@ describe('search query builder', () => {
     cy.get('[data-testid="operators"]').select('contains');
     cy.get('[data-testid="value-editor"]').type('box');
     // press search button
-    cy.get('[aria-label="Search Query"]').click();
+    cy.get('[aria-label="Run Query"]').click();
     // result array should exist
     cy.get('.css-aybym5 > .chakra-heading').should('contain.text', 'search results');
   });

--- a/cypress/e2e/4_entity_edit_attribute.spec.cy.ts
+++ b/cypress/e2e/4_entity_edit_attribute.spec.cy.ts
@@ -5,7 +5,7 @@ describe('In entity page, edit attribute', () => {
     cy.contains('button', 'Dashboard').click();
     cy.get('button').contains('View').eq(-1).click();
     cy.get('button').contains('View').eq(0).click();
-    cy.contains('No Attributes.').should('exist');
+    cy.contains('This Entity does not have any Attributes.').should('exist');
     cy.contains('button', 'Edit').click();
 
     // add attribute
@@ -25,10 +25,10 @@ describe('In entity page, edit attribute', () => {
 
     cy.contains('button', 'Done').click();
 
-    cy.contains('No Attributes.').should('not.exist');
+    cy.contains('This Entity does not have any Attributes.').should('not.exist');
     cy.reload();
     // check if attribute is added
-    cy.contains('No Attributes.').should('not.exist');
+    cy.contains('This Entity does not have any Attributes.').should('not.exist');
 
     // edit attribute
     cy.contains('button', 'Edit').click();
@@ -36,8 +36,8 @@ describe('In entity page, edit attribute', () => {
     cy.get('button[aria-label="Delete attribute"]').click();
     cy.contains('button', 'Done').click();
     // check if attribute is deleted
-    cy.contains('No Attributes.').should('exist');
+    cy.contains('This Entity does not have any Attributes.').should('exist');
     cy.reload();
-    cy.contains('No Attributes.').should('exist');
+    cy.contains('This Entity does not have any Attributes.').should('exist');
   });
 });

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -309,7 +309,12 @@ export type IconNames =
   "c_right" |
   "c_double_right" |
   "c_up" |
-  "c_down";
+  "c_down" |
+
+  // Sorting
+  "sort" |
+  "sort_up" |
+  "sort_down";
 
 // Query types
 export type QueryOperator = "AND" | "OR";


### PR DESCRIPTION
## Description

* Added to Robin's work on `DataTable` sorting by adding an icon for no-sort state. Also disabled sorting on columns that aren't 'sortable', i.e. checkboxes, buttons.
* More obvious borders on Entity, Attribute, and Project view pages.
* Display message rather than empty table on Entities, Attributes, and Projects pages.

## Ticket

https://dev.azure.com/gt-sse-center/MARS%202023/_workitems/edit/310

## Demo 🎥

<img width="1137" alt="image" src="https://github.com/Brain-Development-and-Disorders-Lab/mars/assets/60735885/4a8d3677-7a4c-49b6-ad92-cb7be1c0b65f">

<img width="1137" alt="image" src="https://github.com/Brain-Development-and-Disorders-Lab/mars/assets/60735885/99a9db82-40db-492b-a25e-7a3514e8f6b0">

<img width="1137" alt="image" src="https://github.com/Brain-Development-and-Disorders-Lab/mars/assets/60735885/ee7c1a9e-1c8d-4536-ba1e-a6775c75d3b7">

