### PR TITLE
MARS-1001 Remove unused env variable

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,7 +7,6 @@ on:
 
 # Note: Environment variables used for server deployment only
 env:
-  CONNECTION_STRING: mongodb://admin:metadataadmin@localhost:27017/
   AZURE_WEBAPP_NAME: mars-server
   AZURE_WEBAPP_PACKAGE_PATH: './server'
   NODE_VERSION: '18.x'


### PR DESCRIPTION
## Description

Removed unused connection string environment variable, primarily to help paper trail on this pull request. The solution to the workflows failing was not copying over all the server environment variables from the local `.env` file into Azure.

## Ticket

Jira: https://ccdresearch.atlassian.net/browse/MARS-1001