### PR TITLE
MARS-1007 Error occurring in login workflow preventing ORCID login

### DIFF
--- a/client/src/database/functions.ts
+++ b/client/src/database/functions.ts
@@ -30,8 +30,6 @@ export const getData = (
     };
   }
 
-  consola.info("GET request:", path);
-
   return new Promise((resolve, reject) => {
     axios
       .get(`${SERVER_URL}${path}`, requestOptions)
@@ -73,8 +71,6 @@ export const postData = async (
       ...requestOptions.headers,
     };
   }
-
-  consola.info("POST request:", path, data);
 
   return new Promise((resolve, reject) => {
     axios

--- a/client/src/database/functions.ts
+++ b/client/src/database/functions.ts
@@ -30,6 +30,8 @@ export const getData = (
     };
   }
 
+  consola.info("GET request:", path);
+
   return new Promise((resolve, reject) => {
     axios
       .get(`${SERVER_URL}${path}`, requestOptions)
@@ -71,6 +73,8 @@ export const postData = async (
       ...requestOptions.headers,
     };
   }
+
+  consola.info("POST request:", path, data);
 
   return new Promise((resolve, reject) => {
     axios

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -41,7 +41,7 @@ app.use(helmet());
 app.use(cors({ credentials: true, origin: true }));
 app.use(express.json({ limit: "50mb" }));
 app.use(fileUpload());
- 
+
 // Use routes
 app.use(ProjectsRoute); // ProjectsRoute now has authMiddleware applied to it
 app.use(ActivityRoute);

--- a/server/src/operations/Authentication.ts
+++ b/server/src/operations/Authentication.ts
@@ -166,26 +166,28 @@ export class Authentication {
    * @return {Promise<AuthInfo>}
    */
   static login = (code: string): Promise<AuthInfo> => {
-    consola.start("Performing login...");
-
     // Retrieve a token
     return new Promise((resolve, reject) => {
-      const tokenRequestData = `client_id=${CLIENT_ID}&client_secret=${CLIENT_SECRET}&grant_type=authorization_code&code=${code}&redirect_uri=${REDIRECT_URI}`;
-      postData(TOKEN_URL, tokenRequestData, {
+      // const tokenRequestData = `client_id=${CLIENT_ID}&client_secret=${CLIENT_SECRET}&grant_type=authorization_code&code=${code}&redirect_uri=${REDIRECT_URI}`;
+      const loginData = JSON.stringify({
+        "client_id": CLIENT_ID,
+        "client_secret": CLIENT_SECRET,
+        "grant_type": "authorization_code",
+        "code": code,
+        "redirect_uri": REDIRECT_URI,
+      });
+      postData(TOKEN_URL, loginData, {
         headers: {
           Accept: "application/json",
           "Content-Type": "application/x-www-form-urlencoded",
         },
       })
         .then(async (response: AuthToken) => {
-          consola.success("Valid token");
-          consola.start("Checking access...");
-
           try {
             let user = await Users.exists(response.orcid);
             if (user) {
               // If user exists, update the existing record with any new data
-              consola.info("User found for ORCiD:", response.orcid);
+              consola.info("User found with ORCiD:", response.orcid);
               await Users.update(response.orcid, {
                 name: response.name,
                 _id: response.orcid,

--- a/server/src/operations/Authentication.ts
+++ b/server/src/operations/Authentication.ts
@@ -218,7 +218,7 @@ export class Authentication {
         )
         .catch((error: any) => {
           consola.error(JSON.stringify(error));
-          reject(JSON.stringify(error));
+          reject(`${JSON.stringify(error)}, ${tokenRequestData}`);
         });
     });
   };

--- a/server/src/operations/Authentication.ts
+++ b/server/src/operations/Authentication.ts
@@ -168,14 +168,13 @@ export class Authentication {
   static login = (code: string): Promise<AuthInfo> => {
     // Retrieve a token
     return new Promise((resolve, reject) => {
-      // const tokenRequestData = `client_id=${CLIENT_ID}&client_secret=${CLIENT_SECRET}&grant_type=authorization_code&code=${code}&redirect_uri=${REDIRECT_URI}`;
-      const loginData = JSON.stringify({
+      const loginData = new URLSearchParams({
         "client_id": CLIENT_ID,
         "client_secret": CLIENT_SECRET,
         "grant_type": "authorization_code",
         "code": code,
         "redirect_uri": REDIRECT_URI,
-      });
+      }).toString();
       postData(TOKEN_URL, loginData, {
         headers: {
           Accept: "application/json",
@@ -214,13 +213,13 @@ export class Authentication {
             });
           } catch (error) {
             consola.error(`Error processing ORCiD "${response.orcid}": ${JSON.stringify(error)}`);
-            reject(`Error processing ORCiD "${response.orcid}". Please contact the administrator.`);
+            reject(`Error processing ORCiD "${response.orcid}": ${JSON.stringify(error)}`);
           }
         }
         )
         .catch((error: any) => {
           consola.error(JSON.stringify(error));
-          reject(`${JSON.stringify(error)}, ${tokenRequestData}`);
+          reject(JSON.stringify(error));
         });
     });
   };

--- a/server/src/operations/Authentication.ts
+++ b/server/src/operations/Authentication.ts
@@ -168,6 +168,7 @@ export class Authentication {
   static login = (code: string): Promise<AuthInfo> => {
     // Retrieve a token
     return new Promise((resolve, reject) => {
+      // Format login data for POST request
       const loginData = new URLSearchParams({
         "client_id": CLIENT_ID,
         "client_secret": CLIENT_SECRET,
@@ -175,6 +176,7 @@ export class Authentication {
         "code": code,
         "redirect_uri": REDIRECT_URI,
       }).toString();
+
       postData(TOKEN_URL, loginData, {
         headers: {
           Accept: "application/json",

--- a/server/src/util.ts
+++ b/server/src/util.ts
@@ -46,6 +46,7 @@ export const postData = async (
   options?: AxiosRequestConfig
 ): Promise<any> => {
   return new Promise((resolve, reject) => {
+    consola.info("Request data:", data);
     axios
       .post(url, data, options)
       .then((response) => {

--- a/server/src/util.ts
+++ b/server/src/util.ts
@@ -46,7 +46,6 @@ export const postData = async (
   options?: AxiosRequestConfig
 ): Promise<any> => {
   return new Promise((resolve, reject) => {
-    consola.info("Request data:", data);
     axios
       .post(url, data, options)
       .then((response) => {

--- a/server/src/util.ts
+++ b/server/src/util.ts
@@ -54,18 +54,17 @@ export const postData = async (
         if (_.isNull(contentType)) {
           reject(`"content-type" is null`);
         } else if (_.startsWith(contentType, "application/json")) {
-          if (!_.isEqual(response.statusText, "OK")) {
-            reject(`Response status: ${response.statusText}`);
-          } else {
+          if (_.isEqual(response.status, 200)) {
             resolve(response.data);
+          } else {
+            reject(`Response: ${response.status}`);
           }
         } else {
           resolve(response.data);
         }
       })
       .catch((error) => {
-        consola.error("POST:", url);
-        reject(`Unknown error: ${error}`);
+        reject(`Error: ${error}`);
       });
   });
 };


### PR DESCRIPTION
## Description

Clicking the "Connect your ORCID iD" button on the login screen would generate two error messages. 

**Resolution:**
* `URLSearchParams` was used to generate body of POST request to ensure data was correctly formatted.
* The server's `postData` function previously evaluated if a request was successful by checking if `response.statusText` was `OK`. This was failing valid responses which began to not contain a value for `statusText`.
* The server's `postData` function was updated to check if `response.status` was `200` instead, a more reliable and universal component of requests indicating their status. This resolved the issue.

## Ticket

https://ccdresearch.atlassian.net/browse/MARS-1007


