### PR TITLE
MARS-1028-Entities-unable-to-be-viewed-in-Workspace

### DIFF
--- a/server/src/resolvers/Attributes.ts
+++ b/server/src/resolvers/Attributes.ts
@@ -61,11 +61,8 @@ export const AttributesResolvers = {
         });
       }
 
-      // Check that Attribute is owned by the user and exists in the Workspace
-      if (
-        attribute.owner === context.user &&
-        _.includes(workspace.attributes, attribute._id)
-      ) {
+      // Check that Attribute exists in the Workspace
+      if (_.includes(workspace.attributes, attribute._id)) {
         return attribute;
       } else {
         throw new GraphQLError(


### PR DESCRIPTION
## Description

Some Entities could not be viewed and would raise a GraphQL error. Error was tracked to `Object` scalar type not handling all Attribute value data types correctly.

## Ticket

https://ccdresearch.atlassian.net/browse/MARS-1028