### PR TITLE
MARS-1029-Activity-returning-only-one-instance-in-Workspace

### DIFF
--- a/cypress/e2e/1_launch.spec.cy.ts
+++ b/cypress/e2e/1_launch.spec.cy.ts
@@ -10,6 +10,7 @@ describe("Interface launches", () => {
     // Create a Workspace
     cy.get("#modalWorkspaceName").type("Test Workspace");
     cy.get("#modalWorkspaceDescription").type("Description for Workspace");
+    cy.wait(4200); // Wait for toast to disappear
     cy.get("#modalWorkspaceCreateButton").click();
   });
 

--- a/server/src/models/Activity.ts
+++ b/server/src/models/Activity.ts
@@ -18,6 +18,7 @@ export class Activity {
     return await getDatabase()
       .collection<ActivityModel>(ACTIVITY_COLLECTION)
       .find()
+      .sort({ timestamp: -1 })
       .toArray();
   };
 
@@ -29,6 +30,7 @@ export class Activity {
     return await getDatabase()
       .collection<ActivityModel>(ACTIVITY_COLLECTION)
       .find({ _id: { $in: activities } })
+      .sort({ timestamp: -1 })
       .toArray();
   };
 

--- a/server/src/util.ts
+++ b/server/src/util.ts
@@ -44,5 +44,5 @@ export const authenticate = (request: any, response: any, next: () => void) => {
 export const getIdentifier = (
   type: "entity" | "attribute" | "activity" | "project" | "workspace",
 ): string => {
-  return `${type.slice(0, 1)}${nanoid(7)}`;
+  return `${type.slice(0, 1)}${nanoid(9)}`;
 };


### PR DESCRIPTION
## Description

Activity was only returning a single instance in the Workspace. This was an issue translating existing MongoDB-style IDs into strings for indexing. All IDs are now standard IDs, and future IDs will be `a` plus 9 unique characters instead of 7.

## Ticket

https://ccdresearch.atlassian.net/browse/MARS-1029
