### PR TITLE
MARS-1035-Attachments-fail-to-load-on-first-preview

### DIFF
--- a/client/src/components/PreviewModal/index.tsx
+++ b/client/src/components/PreviewModal/index.tsx
@@ -219,6 +219,7 @@ const PreviewModal = (props: PreviewModalProps) => {
                 rounded={"md"}
                 border={"1px"}
                 borderColor={"gray.200"}
+                minH={"400px"}
                 mb={"2"}
               >
                 <TransformComponent>


### PR DESCRIPTION
## Description

Server would return the static image path before the image was written to disk.

## Ticket

https://ccdresearch.atlassian.net/browse/MARS-1035