### PR TITLE
MARS-1045-Add-text-describing-table-pagination-with-item-count-and-names

### DIFF
--- a/client/src/components/DataTable/index.tsx
+++ b/client/src/components/DataTable/index.tsx
@@ -15,7 +15,6 @@ import {
   Tr,
   Text,
   Checkbox,
-  Spacer,
   Menu,
   MenuButton,
   Button,
@@ -133,6 +132,50 @@ const DataTable = (props: DataTableProps) => {
   useEffect(() => {
     setSelectedRows(props.selectedRows);
   }, [props.selectedRows]);
+
+  // Add a counter for the number of presented paginated items
+  const [itemCountComponent, setItemCountComponent] = useState(<Flex></Flex>);
+  const updateItemCountComponent = () => {
+    const page = table.getState().pagination.pageIndex;
+    const pageSize = table.getState().pagination.pageSize;
+
+    if (props.data.length === 0) {
+      setItemCountComponent(<Flex></Flex>);
+    } else if (page === 0) {
+      setItemCountComponent(
+        <Flex direction={"row"} gap={"1"} align={"center"}>
+          <Text fontSize={"sm"}>Showing:</Text>
+          <Text fontSize={"sm"} fontWeight={"semibold"}>
+            1 - {props.data.length > pageSize ? pageSize : props.data.length}
+          </Text>
+          <Text fontSize={"sm"}>of {props.data.length}</Text>
+        </Flex>,
+      );
+    } else if (page < table.getPageCount() - 1) {
+      setItemCountComponent(
+        <Flex direction={"row"} gap={"1"} align={"center"}>
+          <Text fontSize={"sm"}>Showing:</Text>
+          <Text fontSize={"sm"} fontWeight={"semibold"}>
+            {pageSize * page + 1} - {pageSize * (page + 1)}
+          </Text>
+          <Text fontSize={"sm"}>of {props.data.length}</Text>
+        </Flex>,
+      );
+    } else {
+      setItemCountComponent(
+        <Flex direction={"row"} gap={"1"} align={"center"}>
+          <Text fontSize={"sm"}>Showing:</Text>
+          <Text fontSize={"sm"} fontWeight={"semibold"}>
+            {pageSize * page + 1} - {props.data.length}
+          </Text>
+          <Text fontSize={"sm"}>of {props.data.length}</Text>
+        </Flex>,
+      );
+    }
+  };
+  useEffect(() => {
+    updateItemCountComponent();
+  }, [table.getState().pagination.pageIndex, props.data.length]);
 
   // Exclude columns that are not sortable, i.e. checkboxes and buttons
   const canSortColumn = (header: any) => {
@@ -286,7 +329,8 @@ const DataTable = (props: DataTableProps) => {
           </Flex>
         )}
 
-        <Spacer />
+        {/* Table item counter */}
+        {props.showItemCount && itemCountComponent}
 
         {props.showPagination && (
           <Flex gap={"4"} wrap={"wrap"}>

--- a/client/src/components/Values/index.tsx
+++ b/client/src/components/Values/index.tsx
@@ -683,6 +683,7 @@ const Values = (props: {
         viewOnly={props.viewOnly}
         actions={actions}
         showPagination
+        showItemCount
         showSelection
       />
 

--- a/client/src/pages/view/Attributes.tsx
+++ b/client/src/pages/view/Attributes.tsx
@@ -177,6 +177,7 @@ const Attributes = () => {
               selectedRows={{}}
               showPagination
               showSelection
+              showItemCount
             />
           ) : (
             <Flex

--- a/client/src/pages/view/Entities.tsx
+++ b/client/src/pages/view/Entities.tsx
@@ -200,7 +200,7 @@ const Entities = () => {
         rounded={"md"}
         bg={"white"}
         wrap={"wrap"}
-        gap={"6"}
+        gap={"4"}
       >
         <Flex
           w={"100%"}
@@ -235,6 +235,7 @@ const Entities = () => {
               actions={actions}
               showSelection
               showPagination
+              showItemCount
             />
           ) : (
             <Flex

--- a/client/src/pages/view/Entity.tsx
+++ b/client/src/pages/view/Entity.tsx
@@ -1595,6 +1595,7 @@ const Entity = () => {
                     viewOnly={!editing}
                     actions={projectsTableActions}
                     showPagination
+                    showItemCount
                     showSelection
                   />
                 )}
@@ -1645,6 +1646,7 @@ const Entity = () => {
                       viewOnly={!editing}
                       actions={attachmentTableActions}
                       showPagination
+                      showItemCount
                       showSelection
                     />
                   )}
@@ -1714,6 +1716,7 @@ const Entity = () => {
                         viewOnly={!editing}
                         actions={originTableActions}
                         showPagination
+                        showItemCount
                         showSelection
                       />
                     ) : (
@@ -1746,6 +1749,7 @@ const Entity = () => {
                         viewOnly={!editing}
                         actions={productTableActions}
                         showPagination
+                        showItemCount
                         showSelection
                       />
                     ) : (
@@ -1802,6 +1806,7 @@ const Entity = () => {
                     selectedRows={{}}
                     viewOnly={!editing}
                     showPagination
+                    showItemCount
                     showSelection
                   />
                 )}

--- a/client/src/pages/view/Project.tsx
+++ b/client/src/pages/view/Project.tsx
@@ -878,6 +878,7 @@ const Project = () => {
                     showSelection={true}
                     actions={entitiesTableActions}
                     showPagination
+                    showItemCount
                   />
                 ) : (
                   <Flex w={"100%"} justify={"center"} align={"center"}>

--- a/client/src/pages/view/Projects.tsx
+++ b/client/src/pages/view/Projects.tsx
@@ -186,6 +186,7 @@ const Projects = () => {
               selectedRows={{}}
               showPagination
               showSelection
+              showItemCount
             />
           ) : (
             <Flex

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -304,6 +304,7 @@ export type DataTableProps = {
 
   // Interface visibility
   showPagination?: boolean;
+  showItemCount?: boolean; // Show text at the bottom of the table orienting the user
   showSelection?: boolean;
   actions?: DataTableAction[];
 };


### PR DESCRIPTION
## Description

Add prop to optionally display text below a `DataTable` component: "Showing **x - y** of z"

## Ticket

https://ccdresearch.atlassian.net/browse/MARS-1045
