### PR TITLE
MARS-1074-Template-descriptions-cause-UI-overflow

### DIFF
--- a/client/src/pages/view/Entities.tsx
+++ b/client/src/pages/view/Entities.tsx
@@ -137,11 +137,9 @@ const Entities = () => {
           return <Tag colorScheme={"orange"}>Empty</Tag>;
         }
         return (
-          <Tooltip label={info.getValue()} hasArrow>
-            <Text fontSize={"sm"}>
-              {_.truncate(info.getValue(), { length: 20 })}
-            </Text>
-          </Tooltip>
+          <Text fontSize={"sm"}>
+            {_.truncate(info.getValue(), { length: 20 })}
+          </Text>
         );
       },
       header: "Description",

--- a/client/src/pages/view/Projects.tsx
+++ b/client/src/pages/view/Projects.tsx
@@ -137,7 +137,16 @@ const Projects = () => {
       header: "Owner",
     }),
     columnHelper.accessor("description", {
-      cell: (info) => info.getValue(),
+      cell: (info) => {
+        if (_.isEqual(info.getValue(), "") || _.isNull(info.getValue())) {
+          return <Tag colorScheme={"orange"}>Empty</Tag>;
+        }
+        return (
+          <Text fontSize={"sm"}>
+            {_.truncate(info.getValue(), { length: 20 })}
+          </Text>
+        );
+      },
       header: "Description",
       enableHiding: true,
     }),

--- a/client/src/pages/view/Templates.tsx
+++ b/client/src/pages/view/Templates.tsx
@@ -125,7 +125,16 @@ const Templates = () => {
       enableHiding: true,
     }),
     columnHelper.accessor("description", {
-      cell: (info) => info.getValue(),
+      cell: (info) => {
+        if (_.isEqual(info.getValue(), "") || _.isNull(info.getValue())) {
+          return <Tag colorScheme={"orange"}>Empty</Tag>;
+        }
+        return (
+          <Text fontSize={"sm"}>
+            {_.truncate(info.getValue(), { length: 20 })}
+          </Text>
+        );
+      },
       header: "Description",
       enableHiding: true,
     }),


### PR DESCRIPTION
# Pull Request

## Description

* Fix display of `Entities`, `Projects` and `Templates` lists to truncate description and preview UI overflow.

## Ticket

https://ccdresearch.atlassian.net/browse/MARS-1074
