### PR TITLE
MARS-1075-Invalid-Date-shown-for-multiple-TimestampTag-instances

### DIFF
--- a/client/src/components/TimestampTag/index.tsx
+++ b/client/src/components/TimestampTag/index.tsx
@@ -10,6 +10,16 @@ import dayjs from "dayjs";
 import _ from "lodash";
 
 const TimestampTag = (props: { timestamp: string; description?: string }) => {
+  // Handle improperly formed timestamps
+  let dateString = dayjs(props.timestamp).format("DD MMMM YYYY");
+  if (
+    _.isUndefined(props.timestamp) ||
+    _.isEqual(props.timestamp, "") ||
+    _.isEqual(dateString, "Invalid Date")
+  ) {
+    dateString = "No Timestamp";
+  }
+
   return (
     <Flex direction={"column"} gap={"1"}>
       <Flex
@@ -24,7 +34,7 @@ const TimestampTag = (props: { timestamp: string; description?: string }) => {
         <Icon name={"v_date"} size={"sm"} color={"orange"} />
         <Flex direction={"column"} gap={"0"}>
           <Text fontSize={"sm"} fontWeight={"semibold"}>
-            {dayjs(props.timestamp).format("DD MMMM YYYY")}
+            {dateString}
           </Text>
           <Text fontSize={"xs"} fontWeight={"semibold"} color={"gray.400"}>
             {_.isUndefined(props.description) ? "Timestamp" : props.description}


### PR DESCRIPTION
# Pull Request

## Description

* Update `TimestampTag` component to handle invalid `timestamp` props gracefully.
* Present "No Timestamp" text if timestamp is invalid.

## Ticket

https://ccdresearch.atlassian.net/browse/MARS-1075