### PR TITLE
MARS-1076-Force-input-User-information-on-first-sign-in

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -43,6 +43,7 @@ import Search from "@pages/Search";
 import Dashboard from "@pages/Dashboard";
 import Invalid from "@pages/Invalid";
 import Login from "@pages/Login";
+import Setup from "@pages/Setup";
 
 // Providers
 import { WorkspaceProvider } from "./hooks/useWorkspace";
@@ -113,6 +114,7 @@ const App = (): ReactElement => {
               </Route>
 
               <Route path={"/login"} element={<Login />} />
+              <Route path={"/setup"} element={<Setup />} />
             </Routes>
           </WorkspaceProvider>
         </AuthenticationProvider>

--- a/client/src/components/Container/index.tsx
+++ b/client/src/components/Container/index.tsx
@@ -46,11 +46,13 @@ const Content: FC<ContentProps> = ({ children, isError, isLoaded }) => {
 // Page container
 const Page: FC = () => {
   // Observe the authentication state
-  const { isAuthenticated } = useAuthentication();
+  const { token } = useAuthentication();
 
-  if (!isAuthenticated) {
+  if (token.token === "") {
     // If not authenticated, return the user to the Login page
     return <Navigate to={"/login"} />;
+  } else if (token.setup === false) {
+    return <Navigate to={"/setup"} />;
   } else {
     // Display content
     return (

--- a/client/src/components/Loading/index.tsx
+++ b/client/src/components/Loading/index.tsx
@@ -13,6 +13,7 @@ const Loading = () => {
       gap={"3"}
       p={"8"}
       m={"8"}
+      minH={"90vh"}
       h={"100%"}
     >
       <Spinner size="xl" />

--- a/client/src/hooks/useAuthentication/index.tsx
+++ b/client/src/hooks/useAuthentication/index.tsx
@@ -109,6 +109,10 @@ export const AuthenticationProvider = (props: {
     }
   };
 
+  /**
+   * Function to log out the current user, resets the token to default values and navigates
+   * to the `/login` path
+   */
   const logout = () => {
     // Invalidate the token
     setToken({
@@ -125,8 +129,8 @@ export const AuthenticationProvider = (props: {
   };
 
   /**
-   * Utility function to perform a Login operation
-   * @param code String returned by ORCID API for login
+   * Utility function that logs in the current user and updates the token with received values
+   * @param code returned by ORCID API for login
    */
   const login = async (code: string): Promise<IResponseMessage> => {
     // Query to retrieve Entity data and associated data for editing
@@ -177,6 +181,11 @@ export const AuthenticationProvider = (props: {
     };
   };
 
+  /**
+   * Setup operation to create a new `UserModel` instance and update the token data
+   * @param user Data provided by the user to create a `UserModel` instance
+   * @return {Promise<IResponseMessage>}
+   */
   const setup = async (user: Partial<UserModel>): Promise<IResponseMessage> => {
     const result = await updateUser({
       variables: {
@@ -223,6 +232,7 @@ export const AuthenticationProvider = (props: {
     [token],
   );
 
+  // Return the `React.Context` component
   return (
     <AuthenticationContext.Provider value={value}>
       {props.children}

--- a/client/src/pages/Login.tsx
+++ b/client/src/pages/Login.tsx
@@ -58,22 +58,31 @@ const Login = () => {
   // Extract query parameters
   const accessCode = parameters.get("code");
 
+  /**
+   * Run the login operation, receiving a login code from the ORCiD API, then attempting to execute
+   * the login operation on the backend
+   * @param code Code provided as parameter of redirect URI
+   */
   const runLogin = async (code: string) => {
     setIsLoading(true);
     const result = await login(code);
 
     if (result.success) {
-      // If successful login, check if is the user is setup
+      // If successful login, check if setup is completed
       setIsLoading(false);
 
       if (token.setup === true) {
+        // Navigate to the dashboard after activating a Workspace
         await activateWorkspace("");
         navigate("/");
       } else {
+        // Navigate to the Setup interface
         navigate("/setup");
       }
     } else {
       setIsLoading(false);
+
+      // Provide error information
       if (
         result.message.includes("Unable") &&
         !toast.isActive("login-graphql-error-toast")
@@ -126,20 +135,25 @@ const Login = () => {
     }
   };
 
+  /**
+   * Utility function to examine the login state, as a composition of other states,
+   * and navigate the user accordingly
+   */
   const checkLoginState = async () => {
     if (accessCode && token.token === "") {
-      // Not yet authenticated
+      // Not authenticated, no interest in setup yet
       runLogin(accessCode);
     } else if (token.token !== "" && token.setup === false) {
-      // Authenticated, but not setup
+      // Authenticated but not setup
       navigate("/setup");
     } else if (token.token !== "" && token.setup === true) {
+      // Authenticated and setup
       await activateWorkspace("");
       navigate("/");
     }
   };
 
-  // On the page load, check if access code has been included in the URL
+  // On the page load, evaluate the login state components
   useEffect(() => {
     checkLoginState();
   }, []);

--- a/client/src/pages/Setup.tsx
+++ b/client/src/pages/Setup.tsx
@@ -29,8 +29,8 @@ const Setup = () => {
 
   const navigate = useNavigate();
 
-  // Login state
-  const [isLoading, setIsLoading] = useState(false);
+  // Loading state
+  const [isLoading, setIsLoading] = useState(true);
 
   // User information state
   const [userFirstName, setUserFirstName] = useState("");
@@ -66,11 +66,15 @@ const Setup = () => {
     }
   };
 
+  /**
+   * Utility function to examine the setup state, as a composition of state components
+   */
   const checkSetupState = async () => {
     if (token.setup === true) {
       await activateWorkspace("");
       navigate("/");
     }
+    setIsLoading(false);
   };
 
   useEffect(() => {
@@ -78,7 +82,7 @@ const Setup = () => {
   }, []);
 
   return (
-    <Content>
+    <Content isLoaded={!isLoading}>
       <Flex h={"10vh"} p={"4"}>
         <Flex gap={"2"} align={"center"} p={"4"}>
           <Image src={"/Favicon.png"} w={"25px"} h={"25px"} />

--- a/client/src/pages/Setup.tsx
+++ b/client/src/pages/Setup.tsx
@@ -1,0 +1,197 @@
+// React
+import React, { useEffect, useState } from "react";
+
+// Existing and custom components
+import {
+  Flex,
+  Heading,
+  Button,
+  Image,
+  Text,
+  FormControl,
+  Tag,
+  FormLabel,
+  Input,
+} from "@chakra-ui/react";
+import { Content } from "@components/Container";
+import Icon from "@components/Icon";
+
+// Routing and navigation
+import { useNavigate } from "react-router-dom";
+
+// Contexts
+import { useAuthentication } from "@hooks/useAuthentication";
+import { useWorkspace } from "@hooks/useWorkspace";
+
+const Setup = () => {
+  const { token, setup } = useAuthentication();
+  const { activateWorkspace } = useWorkspace();
+
+  const navigate = useNavigate();
+
+  // Login state
+  const [isLoading, setIsLoading] = useState(false);
+
+  // User information state
+  const [userFirstName, setUserFirstName] = useState("");
+  const [userLastName, setUserLastName] = useState("");
+  const [userEmail, setUserEmail] = useState("");
+  const [userAffiliation, setUserAffiliation] = useState("");
+  const userComplete =
+    userFirstName !== "" &&
+    userLastName !== "" &&
+    userEmail !== "" &&
+    userAffiliation !== "";
+
+  /**
+   * Handle the "Done" button being clicked after user information is entered
+   */
+  const onDoneClick = async () => {
+    setIsLoading(true);
+
+    const result = await setup({
+      _id: token.orcid,
+      firstName: userFirstName,
+      lastName: userLastName,
+      email: userEmail,
+      affiliation: userAffiliation,
+    });
+
+    setIsLoading(false);
+
+    if (result.success === true) {
+      // Activate a Workspace and navigate to the Dashboard
+      await activateWorkspace("");
+      navigate("/");
+    }
+  };
+
+  const checkSetupState = async () => {
+    if (token.setup === true) {
+      await activateWorkspace("");
+      navigate("/");
+    }
+  };
+
+  useEffect(() => {
+    checkSetupState();
+  }, []);
+
+  return (
+    <Content>
+      <Flex h={"10vh"} p={"4"}>
+        <Flex gap={"2"} align={"center"} p={"4"}>
+          <Image src={"/Favicon.png"} w={"25px"} h={"25px"} />
+          <Heading size={"md"}>Metadatify</Heading>
+        </Flex>
+      </Flex>
+      <Flex
+        direction={"column"}
+        justify={"center"}
+        align={"center"}
+        alignSelf={"center"}
+        gap={"8"}
+        w={["sm", "md", "lg"]}
+        h={"90vh"}
+        wrap={"wrap"}
+      >
+        <Flex
+          direction={"column"}
+          p={"8"}
+          gap={"4"}
+          bg={"white"}
+          align={"center"}
+          justify={"center"}
+          border={"1px"}
+          borderColor={"gray.300"}
+          rounded={"md"}
+        >
+          <Heading size={"xl"} fontWeight={"semibold"}>
+            Create your account
+          </Heading>
+
+          <Text fontWeight={"semibold"} fontSize={"sm"}>
+            Complete your account information before continuing.
+          </Text>
+
+          <Flex
+            direction={"row"}
+            gap={"2"}
+            w={"100%"}
+            align={"center"}
+            justify={"left"}
+            pt={"8"}
+          >
+            <Text fontWeight={"semibold"}>ORCiD:</Text>
+            <Tag colorScheme={"green"}>{token.orcid}</Tag>
+          </Flex>
+
+          <FormControl isRequired>
+            <Flex direction={"column"} gap={"2"}>
+              <Flex direction={"row"} gap={"2"}>
+                <Flex direction={"column"} w={"100%"}>
+                  <FormLabel>First Name</FormLabel>
+                  <Input
+                    id={"userFirstNameInput"}
+                    size={"sm"}
+                    rounded={"md"}
+                    value={userFirstName}
+                    onChange={(event) => setUserFirstName(event.target.value)}
+                  />
+                </Flex>
+                <Flex direction={"column"} w={"100%"}>
+                  <FormLabel>Last Name</FormLabel>
+                  <Input
+                    id={"userLastNameInput"}
+                    size={"sm"}
+                    rounded={"md"}
+                    value={userLastName}
+                    onChange={(event) => setUserLastName(event.target.value)}
+                  />
+                </Flex>
+              </Flex>
+              <Flex direction={"column"} gap={"2"}>
+                <Flex direction={"column"}>
+                  <FormLabel>Email</FormLabel>
+                  <Input
+                    id={"userEmailInput"}
+                    size={"sm"}
+                    rounded={"md"}
+                    type={"email"}
+                    value={userEmail}
+                    onChange={(event) => setUserEmail(event.target.value)}
+                  />
+                </Flex>
+                <Flex direction={"column"}>
+                  <FormLabel>Affiliation</FormLabel>
+                  <Input
+                    id={"userAffiliationInput"}
+                    size={"sm"}
+                    rounded={"md"}
+                    value={userAffiliation}
+                    onChange={(event) => setUserAffiliation(event.target.value)}
+                  />
+                </Flex>
+              </Flex>
+            </Flex>
+          </FormControl>
+          <Flex align={"center"} justify={"right"} w={"100%"}>
+            <Button
+              id={"userDoneButton"}
+              rightIcon={<Icon name={"check"} />}
+              colorScheme={"green"}
+              size={"sm"}
+              onClick={() => onDoneClick()}
+              isLoading={isLoading}
+              isDisabled={!userComplete}
+            >
+              Done
+            </Button>
+          </Flex>
+        </Flex>
+      </Flex>
+    </Content>
+  );
+};
+
+export default Setup;

--- a/client/src/pages/view/User.tsx
+++ b/client/src/pages/view/User.tsx
@@ -172,7 +172,7 @@ const User = () => {
   const breakpoint = useBreakpoint();
 
   // Authentication
-  const { token, setToken } = useAuthentication();
+  const { token } = useAuthentication();
 
   // Query to get a User and Workspaces
   const GET_USER = gql`
@@ -311,11 +311,6 @@ const User = () => {
     } else {
       // Update the displayed name
       setStaticName(`${userFirstName} ${userLastName}`);
-
-      // Update the token data
-      const updatedToken = _.cloneDeep(token);
-      updatedToken.name = `${userFirstName} ${userLastName}`;
-      setToken(updatedToken);
     }
 
     setEditing(false);

--- a/client/src/util.ts
+++ b/client/src/util.ts
@@ -73,9 +73,9 @@ export const getToken = (tokenKey: string): IAuth => {
     return JSON.parse(storedToken);
   }
   return {
-    name: "",
     orcid: "",
     token: "",
+    setup: false,
   };
 };
 

--- a/server/src/models/Authentication.ts
+++ b/server/src/models/Authentication.ts
@@ -69,36 +69,20 @@ export class Authentication {
 
     // Check if the User exists, and create a new User if not
     const user = await Users.getOne(authenticationPayload.orcid);
-    if (
-      _.isNull(user) &&
-      !_.isEqual(authenticationPayload.orcid, DEMO_USER_ORCID)
-    ) {
-      // Preview use only, User must exist prior to first login
-      return {
-        success: false,
-        message: "User does not have access",
-        data: {
-          name: authenticationPayload.name,
-          orcid: authenticationPayload.orcid,
-          token: "",
-        },
-      };
-    } else if (_.isNull(user)) {
-      // If the user is the demo user, create a new User
+    if (_.isNull(user)) {
       await Users.create({
         _id: authenticationPayload.orcid,
-        firstName: "Test",
-        lastName: "User",
-        email: "demo@metadatify.com",
-        affiliation: "Metadatify",
+        firstName: "",
+        lastName: "",
+        email: "",
+        affiliation: "",
         lastLogin: dayjs(Date.now()).toISOString(),
         token: authenticationPayload.token,
         workspaces: [],
         api_keys: [],
       });
-    }
-
-    if (!_.isNull(user)) {
+    } else {
+      // If the User does exist, update the `lastLogin` timestamp
       user.lastLogin = dayjs(Date.now()).toISOString();
       await Users.update(user);
     }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -477,9 +477,9 @@ export type ResponseData<D> = IResponseMessage & {
 
 // Authentication types
 export type IAuth = {
-  name: string; // User name
   orcid: string; // ORCiD value
   token: string; // ORCiD token
+  setup: boolean; // Flag if application setup is complete
 };
 
 export type Token = IAuth & {


### PR DESCRIPTION
# Pull Request

## Description

* Create a mechanism where users are prompted to setup an account on their first login, if the corresponding `UserModel` is incomplete.
* Created a new `/setup` endpoint, which is accessed after `/login` if additional setup is required.
* This can potentially be used in the future to create a first login workflow.
* Refactored some `useAuthentication` logic to remove over-complicated state, relying on the token instead.

## Ticket

https://ccdresearch.atlassian.net/browse/MARS-1076
