### PR TITLE
MARS-1096-Query-builder-failing-when-sub-groups-created

### DIFF
--- a/client/src/components/SearchQueryBuilder/index.tsx
+++ b/client/src/components/SearchQueryBuilder/index.tsx
@@ -100,17 +100,16 @@ const SearchQueryBuilder: React.FC<SearchQueryBuilderProps> = ({
    */
   const ruleProcessor: RuleProcessor = (rule: RuleType): any => {
     if (rule.field === "name") {
+      const value = { $regex: new RegExp(rule.value, "gi").toString() };
       if (rule.operator === "doesNotContain") {
         return {
           name: {
-            $not: { $regex: new RegExp(rule.value, "gi").toString() },
+            $not: value,
           },
         };
       } else if (rule.operator === "contains") {
         return {
-          name: {
-            $regex: new RegExp(rule.value, "gi").toString(),
-          },
+          name: value,
         };
       } else {
         return defaultRuleProcessorMongoDB(rule);
@@ -138,80 +137,79 @@ const SearchQueryBuilder: React.FC<SearchQueryBuilderProps> = ({
         };
       }
     } else if (rule.field === "attributes") {
-      // Construct the base query components
+      // Parse the custom rule
       const customRule = JSON.parse(rule.value);
-      const processed = {
-        "attributes.values.type": customRule.type,
-      };
+
+      // Create a base custom rule structure
+      const processedCustomRules: Record<string, any>[] = [
+        { "attributes.values.type": customRule.type },
+      ];
 
       // Append query components depending on the specified operator
       if (customRule.operator === "contains") {
-        return {
-          ...processed,
+        processedCustomRules.push({
           "attributes.values.data": {
             $regex: new RegExp(customRule.value, "gi").toString(),
           },
-        };
+        });
       } else if (customRule.operator === "does not contain") {
-        return {
-          ...processed,
+        processedCustomRules.push({
           "attributes.values.data": {
             $not: {
               $regex: new RegExp(customRule.value, "gi").toString(),
             },
           },
-        };
+        });
       } else if (customRule.operator === "equals") {
         if (customRule.type === "number") {
-          return {
-            ...processed,
+          processedCustomRules.push({
             "attributes.values.data": {
               $eq: parseFloat(customRule.value),
             },
-          };
+          });
         } else {
-          return {
-            ...processed,
+          processedCustomRules.push({
             "attributes.values.data": {
               $eq: dayjs(customRule.value).format("YYYY-MM-DD"),
             },
-          };
+          });
         }
       } else if (customRule.operator === ">") {
         if (customRule.type === "number") {
-          return {
-            ...processed,
+          processedCustomRules.push({
             "attributes.values.data": {
               $gt: parseFloat(customRule.value),
             },
-          };
+          });
         } else {
-          return {
-            ...processed,
+          processedCustomRules.push({
             "attributes.values.data": {
               $gt: dayjs(customRule.value).format("YYYY-MM-DD"),
             },
-          };
+          });
         }
       } else if (customRule.operator === "<") {
         if (customRule.type === "number") {
-          return {
-            ...processed,
+          processedCustomRules.push({
             "attributes.values.data": {
               $lt: parseFloat(customRule.value),
             },
-          };
+          });
         } else {
-          return {
-            ...processed,
+          processedCustomRules.push({
             "attributes.values.data": {
               $lt: dayjs(customRule.value).format("YYYY-MM-DD"),
             },
-          };
+          });
         }
       }
 
-      return processed;
+      // Handle the operator
+      if (rule.operator === "doesNotContain") {
+        return { $nor: processedCustomRules };
+      } else {
+        return { $and: processedCustomRules };
+      }
     }
 
     // Default rule applied
@@ -266,7 +264,6 @@ const SearchQueryBuilder: React.FC<SearchQueryBuilderProps> = ({
   const onSearchBuiltQuery = async () => {
     setIsSearching(true);
     setHasSearched(true);
-
     // Format the query in `mongodb` format before sending
     const results = await searchText({
       variables: {
@@ -371,7 +368,6 @@ const SearchQueryBuilder: React.FC<SearchQueryBuilderProps> = ({
                 fields={fields}
                 onQueryChange={setQuery}
                 controlElements={{ valueEditor: SearchQueryValue }}
-                showNotToggle
                 enableDragAndDrop
               />
             </QueryBuilderDnD>

--- a/client/src/components/SearchQueryBuilder/index.tsx
+++ b/client/src/components/SearchQueryBuilder/index.tsx
@@ -264,6 +264,7 @@ const SearchQueryBuilder: React.FC<SearchQueryBuilderProps> = ({
   const onSearchBuiltQuery = async () => {
     setIsSearching(true);
     setHasSearched(true);
+
     // Format the query in `mongodb` format before sending
     const results = await searchText({
       variables: {

--- a/client/src/pages/Login.tsx
+++ b/client/src/pages/Login.tsx
@@ -170,7 +170,7 @@ const Login = () => {
         alignSelf={"center"}
         gap={"8"}
         w={["sm", "md", "lg"]}
-        h={"90vh"}
+        h={"80vh"} // Header is 10vh, so 90vh - 10vh = 80vh
         wrap={"wrap"}
       >
         <Flex direction={"column"} gap={"4"}>

--- a/client/src/pages/Search.tsx
+++ b/client/src/pages/Search.tsx
@@ -18,6 +18,7 @@ import {
   Tabs,
   Tag,
   Text,
+  Tooltip,
   useBreakpoint,
   useToast,
 } from "@chakra-ui/react";
@@ -171,13 +172,19 @@ const Search = () => {
     searchResultColumnHelper.accessor("description", {
       cell: (info) => {
         if (_.isEqual(info.getValue(), "") || _.isNull(info.getValue())) {
-          return (
-            <Tag colorScheme={"orange"} size={"sm"}>
-              No Description
-            </Tag>
-          );
+          return <Tag colorScheme={"orange"}>No Description</Tag>;
         }
-        return <Text noOfLines={1}>{info.getValue()}</Text>;
+        return (
+          <Tooltip
+            label={info.getValue()}
+            placement={"top"}
+            isDisabled={info.getValue().length < 30}
+          >
+            <Text noOfLines={1}>
+              {_.truncate(info.getValue(), { length: 30 })}
+            </Text>
+          </Tooltip>
+        );
       },
       header: "Description",
       enableHiding: true,

--- a/client/src/pages/Setup.tsx
+++ b/client/src/pages/Setup.tsx
@@ -104,7 +104,7 @@ const Setup = () => {
         alignSelf={"center"}
         gap={"8"}
         w={["sm", "md", "lg"]}
-        h={"90vh"}
+        h={"80vh"} // Header is 10vh, so 90vh - 10vh = 80vh
         wrap={"wrap"}
       >
         <Flex

--- a/client/src/pages/create/User.tsx
+++ b/client/src/pages/create/User.tsx
@@ -145,7 +145,7 @@ const User = () => {
         alignSelf={"center"}
         gap={"8"}
         w={["sm", "md", "lg"]}
-        h={"90vh"}
+        h={"80vh"} // Header is 10vh, so 90vh - 10vh = 80vh
         wrap={"wrap"}
       >
         <Flex

--- a/client/src/pages/view/Workspace.tsx
+++ b/client/src/pages/view/Workspace.tsx
@@ -7,7 +7,6 @@ import {
   FormLabel,
   Input,
   Button,
-  VStack,
   IconButton,
   Text,
   useToast,
@@ -692,16 +691,16 @@ const Workspace = () => {
       </Flex>
 
       <Flex direction={"column"} gap={"2"} p={"2"}>
-        <Flex direction={"row"} p={"0"} gap={"2"} grow={"1"} wrap={"wrap"}>
+        <Flex direction={"row"} gap={"2"} p={"0"} wrap={"wrap"}>
           {/* Workspace name */}
           <Flex
             direction={"column"}
-            w={{ base: "100%", md: "50%" }}
-            h={"fit-content"}
             p={"2"}
+            h={"fit-content"}
             gap={"2"}
-            rounded={"md"}
             bg={"gray.100"}
+            rounded={"md"}
+            basis={"50%"}
           >
             <Flex direction={"row"} gap={"2"}>
               <Flex grow={"1"}>
@@ -746,13 +745,14 @@ const Workspace = () => {
 
           {/* Workspace description */}
           <Flex
-            direction={"column"}
-            w={{ base: "100%", md: "50%" }}
+            direction={"row"}
             p={"2"}
+            h={"fit-content"}
             gap={"2"}
-            rounded={"md"}
             border={"1px"}
             borderColor={"gray.300"}
+            rounded={"md"}
+            grow={"1"}
           >
             <FormControl>
               <FormLabel fontSize={"sm"} fontWeight={"semibold"}>
@@ -774,35 +774,38 @@ const Workspace = () => {
           </Flex>
         </Flex>
 
-        <Flex direction={"row"} p={"0"} gap={"2"} grow={"1"} wrap={"wrap"}>
+        <Flex direction={"row"} gap={"2"} p={"0"} wrap={"wrap"}>
           {/* Workspace collaborators */}
           <Flex
             direction={"column"}
-            w={{ base: "100%", md: "50%" }}
             p={"2"}
             gap={"2"}
-            rounded={"md"}
+            h={"fit-content"}
             border={"1px"}
             borderColor={"gray.300"}
+            rounded={"md"}
+            basis={"50%"}
           >
             <Text fontSize={"sm"} fontWeight={"semibold"}>
               Collaborators
             </Text>
-            <Text fontSize={"sm"} fontWeight={"semibold"} color={"gray.400"}>
-              Add Collaborators by their ORCiD, and they will have access to
-              this Workspace when they next sign into Metadatify.
-            </Text>
+            <Flex>
+              <Text fontSize={"sm"} fontWeight={"semibold"} color={"gray.400"}>
+                Add Collaborators by their ORCiD.
+              </Text>
+            </Flex>
             <Flex direction={"row"} gap={"2"} align={"center"}>
               <FormControl>
                 <Input
                   placeholder={"ORCiD"}
                   rounded={"md"}
                   size={"sm"}
+                  w={"100%"}
                   value={collaborator}
                   onChange={(event) => setCollaborator(event.target.value)}
                 />
               </FormControl>
-              <Spacer />
+              {/* <Spacer /> */}
               <Button
                 colorScheme={"green"}
                 rightIcon={<Icon name={"add"} />}
@@ -833,7 +836,7 @@ const Workspace = () => {
                   No Collaborators
                 </Text>
               ) : (
-                <VStack w={"100%"} spacing={"0"}>
+                <Flex w={"100%"} direction={"column"} gap={"2"}>
                   {collaborators.map((collaborator, index) => (
                     <Flex
                       key={index}
@@ -877,21 +880,21 @@ const Workspace = () => {
                       />
                     </Flex>
                   ))}
-                </VStack>
+                </Flex>
               )}
             </Flex>
           </Flex>
 
           {/* Workspace Entities */}
           <Flex
-            direction={"column"}
-            w={{ base: "100%", md: "50%" }}
-            h={"fit-content"}
+            direction={"row"}
             p={"2"}
+            h={"fit-content"}
             gap={"2"}
-            rounded={"md"}
             border={"1px"}
             borderColor={"gray.300"}
+            rounded={"md"}
+            grow={"1"}
           >
             <FormControl>
               <FormLabel fontSize={"sm"} fontWeight={"semibold"}>
@@ -923,17 +926,17 @@ const Workspace = () => {
           </Flex>
         </Flex>
 
-        <Flex direction={"row"} p={"0"} gap={"2"} grow={"1"} wrap={"wrap"}>
+        <Flex direction={"row"} p={"0"} gap={"2"} wrap={"wrap"}>
           {/* Workspace Projects */}
           <Flex
             direction={"column"}
-            w={{ base: "100%", md: "50%" }}
-            h={"fit-content"}
             p={"2"}
             gap={"2"}
-            rounded={"md"}
+            h={"fit-content"}
             border={"1px"}
             borderColor={"gray.300"}
+            rounded={"md"}
+            basis={"50%"}
           >
             <FormControl>
               <FormLabel fontSize={"sm"} fontWeight={"semibold"}>
@@ -966,14 +969,14 @@ const Workspace = () => {
 
           {/* Workspace Templates */}
           <Flex
-            direction={"column"}
-            w={{ base: "100%", md: "50%" }}
-            h={"fit-content"}
+            direction={"row"}
             p={"2"}
+            h={"fit-content"}
             gap={"2"}
-            rounded={"md"}
             border={"1px"}
             borderColor={"gray.300"}
+            rounded={"md"}
+            grow={"1"}
           >
             <FormControl>
               <FormLabel fontSize={"sm"} fontWeight={"semibold"}>

--- a/server/package.json
+++ b/server/package.json
@@ -32,7 +32,6 @@
     "graphql": "^16.8.1",
     "graphql-upload": "^16.0.2",
     "helmet": "^7.0.0",
-    "jsonpath-plus": "^10.3.0",
     "jsonwebtoken": "^9.0.1",
     "jwks-rsa": "^3.0.1",
     "lodash": "^4.17.21",

--- a/server/src/models/Entities.ts
+++ b/server/src/models/Entities.ts
@@ -105,6 +105,15 @@ export class Entities {
     entity.name = entity.name.toString().trim();
     entity.description = entity.description.toString().trim();
 
+    // Iterate over all Attributes, casting `number` values to floats
+    entity.attributes.forEach((attribute) => {
+      attribute.values.forEach((value) => {
+        if (value.type === "number") {
+          value.data = parseFloat(value.data);
+        }
+      });
+    });
+
     // Allocate a new identifier and join with IEntity data
     const joinedEntity: EntityModel = {
       _id: getIdentifier("entity"), // Generate new identifier
@@ -233,6 +242,15 @@ export class Entities {
       update.$set.attributes = updated.attributes;
       const updatedAttributes = updated.attributes.map((a) => a._id);
       const entityAttributes = entity.attributes.map((a) => a._id);
+
+      // Iterate over all Attributes, casting `number` values to floats
+      update.$set.attributes.forEach((attribute) => {
+        attribute.values.forEach((value) => {
+          if (value.type === "number") {
+            value.data = parseFloat(value.data);
+          }
+        });
+      });
 
       // Attributes added in updated Entity
       const addAttributeIdentifiers = _.difference(

--- a/server/src/util.ts
+++ b/server/src/util.ts
@@ -1,3 +1,4 @@
+// Utility libraries and functions
 import { nanoid } from "nanoid";
 
 /**

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -1391,16 +1391,6 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
-"@jsep-plugin/assignment@^1.3.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@jsep-plugin/assignment/-/assignment-1.3.0.tgz#fcfc5417a04933f7ceee786e8ab498aa3ce2b242"
-  integrity sha512-VVgV+CXrhbMI3aSusQyclHkenWSAm95WaiKrMxRFam3JSUiIaQjoMIw2sEs/OX4XifnqeQUN4DYbJjlA8EfktQ==
-
-"@jsep-plugin/regex@^1.0.4":
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/@jsep-plugin/regex/-/regex-1.0.4.tgz#cb2fc423220fa71c609323b9ba7f7d344a755fcc"
-  integrity sha512-q7qL4Mgjs1vByCaTnDFcBnV9HS7GVPJX5vyVoCgZHNSC9rjwIlmbXG5sUuorR5ndfHAIlJ8pVStxvjXHbNvtUg==
-
 "@mongodb-js/saslprep@^1.1.0":
   version "1.1.9"
   resolved "https://registry.yarnpkg.com/@mongodb-js/saslprep/-/saslprep-1.1.9.tgz#e974bab8eca9faa88677d4ea4da8d09a52069004"
@@ -4187,11 +4177,6 @@ jsbn@1.1.0:
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-1.1.0.tgz#b01307cb29b618a1ed26ec79e911f803c4da0040"
   integrity sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==
 
-jsep@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/jsep/-/jsep-1.4.0.tgz#19feccbfa51d8a79f72480b4b8e40ce2e17152f0"
-  integrity sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==
-
 jsesc@^2.5.1:
   version "2.5.2"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-2.5.2.tgz#80564d2e483dacf6e8ef209650a67df3f0c283a4"
@@ -4221,15 +4206,6 @@ json5@^2.2.3:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
   integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
-
-jsonpath-plus@^10.3.0:
-  version "10.3.0"
-  resolved "https://registry.yarnpkg.com/jsonpath-plus/-/jsonpath-plus-10.3.0.tgz#59e22e4fa2298c68dfcd70659bb47f0cad525238"
-  integrity sha512-8TNmfeTCk2Le33A3vRRwtuworG/L5RrgMvdjhKZxvyShO+mBu2fP50OWUjRLNtvw344DdDarFh9buFAZs5ujeA==
-  dependencies:
-    "@jsep-plugin/assignment" "^1.3.0"
-    "@jsep-plugin/regex" "^1.0.4"
-    jsep "^1.4.0"
 
 jsonwebtoken@^9.0.1:
   version "9.0.2"


### PR DESCRIPTION
# Pull Request

## Description

* Added new `traverseQueryObject` and `generateMongoQuery` functions as part of refactoring query builder on backend.
* Addressed issues with serializing the JSON-formatted MongoDB query.
* Fixed bug where `number` Values were not being stored as floats, they were stored as strings. Updated production database with this fix for any existing `number` Values.
* Fixed UI of search queries, long Entity descriptions would lead to horizontal overflow.

## Ticket

https://ccdresearch.atlassian.net/browse/MARS-1096
