### PR TITLE
[1110] Add Excel-like column filtering to DataTable component

### DIFF
--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -16,7 +16,7 @@ import {
   Stack,
   EmptyState,
 } from "@chakra-ui/react";
-import { createColumnHelper } from "@tanstack/react-table";
+import { createColumnHelper, ColumnFiltersState } from "@tanstack/react-table";
 import { Content } from "@components/Container";
 import DataTable from "@components/DataTable";
 import Icon from "@components/Icon";
@@ -151,6 +151,10 @@ const Dashboard = () => {
     attributes: true,
     created: true,
   });
+
+  // Column filters state for entity table
+  const [entityColumnFilters, setEntityColumnFilters] =
+    useState<ColumnFiltersState>([]);
 
   // Update column visibility when breakpoint changes
   useEffect(() => {
@@ -685,6 +689,8 @@ const Dashboard = () => {
                   )}
                   visibleColumns={visibleColumns}
                   selectedRows={{}}
+                  columnFilters={entityColumnFilters}
+                  onColumnFiltersChange={setEntityColumnFilters}
                 />
               )}
 

--- a/client/src/pages/view/Entities.tsx
+++ b/client/src/pages/view/Entities.tsx
@@ -24,7 +24,7 @@ import { Content } from "@components/Container";
 import Icon from "@components/Icon";
 import Tooltip from "@components/Tooltip";
 import DataTable from "@components/DataTable";
-import { createColumnHelper } from "@tanstack/react-table";
+import { createColumnHelper, ColumnFiltersState } from "@tanstack/react-table";
 
 // Existing and custom types
 import { DataTableAction, EntityModel, IGenericItem } from "@types";
@@ -54,6 +54,9 @@ const Entities = () => {
     owner: true,
     created: true,
   });
+
+  // Column filters state for entity table
+  const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
 
   // Entities export modal
   const {
@@ -346,6 +349,8 @@ const Entities = () => {
               showSelection
               showPagination
               showItemCount
+              columnFilters={columnFilters}
+              onColumnFiltersChange={setColumnFilters}
             />
           ) : (
             <EmptyState.Root>

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -365,6 +365,8 @@ export type DataTableProps = {
   visibleColumns: Record<string, boolean>;
   selectedRows: any;
   onSelectedRowsChange?: (selectedRows: any[]) => void;
+  columnFilters?: any;
+  onColumnFiltersChange?: (filters: any) => void;
   data: any[];
   setData?: (value: React.SetStateAction<any[]>) => void;
   viewOnly?: boolean;


### PR DESCRIPTION
- Implement ColumnFilterMenu with search, checkboxes, and Select/Clear All
- Add column filter state management to Dashboard and Entities pages
- Handle complex data types (arrays, objects) with proper display values
- Prevent event propagation to avoid triggering sort when clicking filters
- Update DataTableProps type definition to include columnFilters

Features:
- Filter icons on sortable column headers
- Excel-like dropdown with search functionality
- Multi-column filtering with AND logic
- Visual feedback for active filters
- Proper handling of arrays (shows 'X items' instead of [object Object])
- Persistent dropdown during checkbox interactions

## Ticket

https://ccdresearch.atlassian.net/jira/software/projects/MARS/boards/1?selectedIssue=MARS-1110

## Demonstration

<img width="1610" height="597" alt="image" src="https://github.com/user-attachments/assets/7823d335-7e2d-432e-80c3-5c1ca40ced72" />
