### PR TITLE
MARS-1157-Exporting-modals-show-user-ID-instead-of-name

### DIFF
--- a/client/src/components/ActorTag/index.tsx
+++ b/client/src/components/ActorTag/index.tsx
@@ -87,11 +87,13 @@ const ActorTag = (props: ActorTagProps) => {
     );
   }
 
-  return props.inline ? (
-    <Flex direction={"row"} gap={"2"} align={"center"}>
-      <Avatar.Root size={"2xs"} key={actorLabel} colorPalette={loading ? "gray" : pickPalette(actorLabel)}>
-        <Avatar.Fallback name={loading ? "" : actorLabel} />
-      </Avatar.Root>
+  return props.inline || props.inlineNoAvatar ? (
+    <Flex direction={"row"} gap={"0.5"} align={"center"} w={"fit-content"}>
+      {(_.isUndefined(props.inlineNoAvatar) || props.inlineNoAvatar === false) && (
+        <Avatar.Root size={"2xs"} key={actorLabel} colorPalette={loading ? "gray" : pickPalette(actorLabel)}>
+          <Avatar.Fallback name={loading ? "" : actorLabel} />
+        </Avatar.Root>
+      )}
       <Skeleton asChild loading={loading} w={"120px"}>
         <Badge fontSize={"xs"} fontWeight={"semibold"} color={"gray.700"}>
           {!loading && actorLabel}

--- a/client/src/pages/view/Entity.tsx
+++ b/client/src/pages/view/Entity.tsx
@@ -3087,11 +3087,16 @@ const Entity = () => {
                           Entity Details
                         </Fieldset.Legend>
                         {!loading ? (
-                          <Stack gap={1} direction={"column"}>
+                          <Stack gap={"1"} direction={"column"}>
                             <Checkbox.Root disabled defaultChecked fontSize={"xs"} size={"xs"}>
                               <Checkbox.HiddenInput />
                               <Checkbox.Control />
-                              <Checkbox.Label>Name: {entityName}</Checkbox.Label>
+                              <Checkbox.Label>
+                                <Flex fontSize={"xs"} gap={"1"} direction={"row"}>
+                                  <Text fontWeight={"semibold"}>Name:</Text>
+                                  <Text>{entityName}</Text>
+                                </Flex>
+                              </Checkbox.Label>
                             </Checkbox.Root>
                             <Checkbox.Root
                               checked={_.includes(exportFields, "created")}
@@ -3101,12 +3106,22 @@ const Entity = () => {
                             >
                               <Checkbox.HiddenInput />
                               <Checkbox.Control />
-                              <Checkbox.Label>Created: {dayjs(entity.created).format("DD MMM YYYY")}</Checkbox.Label>
+                              <Checkbox.Label>
+                                <Flex fontSize={"xs"} gap={"1"} direction={"row"}>
+                                  <Text fontWeight={"semibold"}>Created:</Text>
+                                  <Text>{dayjs(entity.created).format("DD MMM YYYY")}</Text>
+                                </Flex>
+                              </Checkbox.Label>
                             </Checkbox.Root>
                             <Checkbox.Root checked={true} disabled fontSize={"xs"} size={"xs"}>
                               <Checkbox.HiddenInput />
                               <Checkbox.Control />
-                              <Checkbox.Label>Owner: {entity.owner}</Checkbox.Label>
+                              <Checkbox.Label>
+                                <Flex direction={"row"} gap={"0.5"} align={"center"}>
+                                  Owner:
+                                  <ActorTag identifier={entity.owner} inlineNoAvatar fallback={""} size={"sm"} />
+                                </Flex>
+                              </Checkbox.Label>
                             </Checkbox.Root>
                             <Checkbox.Root
                               checked={_.includes(exportFields, "description")}
@@ -3119,14 +3134,16 @@ const Entity = () => {
                               <Checkbox.HiddenInput />
                               <Checkbox.Control />
                               <Checkbox.Label>
-                                <Text lineClamp={1} fontSize={"xs"}>
-                                  Description:{" "}
-                                  {_.isEqual(entityDescription, "")
-                                    ? "No Description"
-                                    : _.truncate(entityDescription, {
-                                        length: 32,
-                                      })}
-                                </Text>
+                                <Flex fontSize={"xs"} gap={"1"} direction={"row"}>
+                                  <Text fontWeight={"semibold"}>Description:</Text>
+                                  <Text lineClamp={1}>
+                                    {_.isEqual(entityDescription, "")
+                                      ? "No Description"
+                                      : _.truncate(entityDescription, {
+                                          length: 32,
+                                        })}
+                                  </Text>
+                                </Flex>
                               </Checkbox.Label>
                             </Checkbox.Root>
                           </Stack>
@@ -3200,7 +3217,14 @@ const Entity = () => {
                                   <Checkbox.HiddenInput />
                                   <Checkbox.Control />
                                   <Checkbox.Label>
-                                    <Linky id={relationship.target._id} type={"entities"} size={"xs"} />
+                                    <Flex direction={"row"} gap={"1"} align={"center"}>
+                                      {relationship.type === "general" ? (
+                                        <Text fontWeight={"semibold"}>Related to:</Text>
+                                      ) : (
+                                        <Text fontWeight={"semibold"}>{_.capitalize(relationship.type)} of:</Text>
+                                      )}
+                                      <Linky id={relationship.target._id} type={"entities"} size={"xs"} />
+                                    </Flex>
                                   </Checkbox.Label>
                                 </Checkbox.Root>
                               );
@@ -3237,7 +3261,12 @@ const Entity = () => {
                                 >
                                   <Checkbox.HiddenInput />
                                   <Checkbox.Control />
-                                  <Checkbox.Label>{attribute.name}</Checkbox.Label>
+                                  <Checkbox.Label>
+                                    <Flex direction={"row"} gap={"0.5"} align={"center"}>
+                                      <Text fontWeight={"semibold"}>Attribute:</Text>
+                                      <Text>{attribute.name}</Text>
+                                    </Flex>
+                                  </Checkbox.Label>
                                 </Checkbox.Root>
                               );
                             })}

--- a/client/src/pages/view/Project.tsx
+++ b/client/src/pages/view/Project.tsx
@@ -1782,7 +1782,12 @@ const Project = () => {
                           <Checkbox.Root disabled defaultChecked size={"xs"} rounded={"md"} fontSize={"xs"}>
                             <Checkbox.HiddenInput />
                             <Checkbox.Control />
-                            <Checkbox.Label fontSize={"xs"}>Name: {projectName}</Checkbox.Label>
+                            <Checkbox.Label>
+                              <Flex fontSize={"xs"} gap={"1"} direction={"row"}>
+                                <Text fontWeight={"semibold"}>Name:</Text>
+                                <Text>{projectName}</Text>
+                              </Flex>
+                            </Checkbox.Label>
                           </Checkbox.Root>
                           <Checkbox.Root
                             size={"xs"}
@@ -1794,7 +1799,10 @@ const Project = () => {
                             <Checkbox.HiddenInput />
                             <Checkbox.Control />
                             <Checkbox.Label fontSize={"xs"}>
-                              Created: {dayjs(project.created).format("DD MMM YYYY")}
+                              <Flex fontSize={"xs"} gap={"1"} direction={"row"}>
+                                <Text fontWeight={"semibold"}>Created:</Text>
+                                <Text>{dayjs(project.created).format("DD MMM YYYY")}</Text>
+                              </Flex>
                             </Checkbox.Label>
                           </Checkbox.Root>
                           <Checkbox.Root
@@ -1805,7 +1813,12 @@ const Project = () => {
                           >
                             <Checkbox.HiddenInput />
                             <Checkbox.Control />
-                            <Checkbox.Label fontSize={"xs"}>Owner: {project.owner}</Checkbox.Label>
+                            <Checkbox.Label>
+                              <Flex direction={"row"} gap={"0.5"} align={"center"}>
+                                Owner:
+                                <ActorTag identifier={project.owner} inlineNoAvatar fallback={""} size={"sm"} />
+                              </Flex>
+                            </Checkbox.Label>
                           </Checkbox.Root>
                           <Checkbox.Root
                             size={"xs"}
@@ -1817,14 +1830,16 @@ const Project = () => {
                             <Checkbox.HiddenInput />
                             <Checkbox.Control />
                             <Checkbox.Label fontSize={"xs"}>
-                              <Text lineClamp={1} fontSize={"xs"}>
-                                Description:{" "}
-                                {_.isEqual(projectDescription, "")
-                                  ? "No Description"
-                                  : _.truncate(projectDescription, {
-                                      length: 32,
-                                    })}
-                              </Text>
+                              <Flex fontSize={"xs"} gap={"1"} direction={"row"}>
+                                <Text fontWeight={"semibold"}>Description:</Text>
+                                <Text lineClamp={1}>
+                                  {_.isEqual(projectDescription, "")
+                                    ? "No Description"
+                                    : _.truncate(projectDescription, {
+                                        length: 32,
+                                      })}
+                                </Text>
+                              </Flex>
                             </Checkbox.Label>
                           </Checkbox.Root>
                         </Stack>
@@ -1853,7 +1868,7 @@ const Project = () => {
                             <Checkbox.Control />
                             <Checkbox.Label fontSize={"xs"}>
                               <Text lineClamp={1} fontSize={"xs"}>
-                                Export Entities
+                                Export all Entities
                               </Text>
                             </Checkbox.Label>
                           </Checkbox.Root>
@@ -1865,17 +1880,18 @@ const Project = () => {
                         <RadioGroup.Root
                           value={exportEntityDetails}
                           onValueChange={(event) => setExportEntityDetails(event.value)}
+                          size={"xs"}
                         >
                           <Stack direction={"row"} gap={"1"}>
                             <RadioGroup.Item value={"name"}>
                               <RadioGroup.ItemHiddenInput />
                               <RadioGroup.ItemIndicator />
-                              <RadioGroup.Label fontSize={"xs"}>Names</RadioGroup.Label>
+                              <RadioGroup.Label fontSize={"xs"}>Names Only</RadioGroup.Label>
                             </RadioGroup.Item>
                             <RadioGroup.Item value={"_id"}>
                               <RadioGroup.ItemHiddenInput />
                               <RadioGroup.ItemIndicator />
-                              <RadioGroup.Label fontSize={"xs"}>Identifiers</RadioGroup.Label>
+                              <RadioGroup.Label fontSize={"xs"}>Identifiers Only</RadioGroup.Label>
                             </RadioGroup.Item>
                           </Stack>
                         </RadioGroup.Root>

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -156,6 +156,7 @@ export type ActorTagProps = {
   fallback: string;
   size: "sm" | "md";
   inline?: boolean;
+  inlineNoAvatar?: boolean;
   avatarOnly?: boolean;
 };
 


### PR DESCRIPTION
# Pull Request

## Description

* Export modals were showing the internal user ID instead of the user's name
* Tidied up the checkboxes for selecting fields for export across Entity and Project view pages

## Ticket

https://ccdresearch.atlassian.net/browse/MARS-1157