### PR TITLE
MARS-1160-Fix-DataTable-select-to-show-the-number-selected-and-enable-partial-selection-after-selecting-all

### DIFF
--- a/client/src/components/DataTable/index.tsx
+++ b/client/src/components/DataTable/index.tsx
@@ -1163,7 +1163,7 @@ const DataTable = (props: DataTableProps) => {
         {props.showPagination && showAdvancedControls && (
           <Flex direction="row" gap={1} align="center" wrap="wrap">
             <Text fontSize="xs" display={{ base: "none", sm: "block" }}>
-              Show Items:
+              Show:
             </Text>
             <Fieldset.Root w="fit-content">
               <Fieldset.Content>

--- a/client/src/components/DataTable/index.tsx
+++ b/client/src/components/DataTable/index.tsx
@@ -445,7 +445,7 @@ const DataTable = (props: DataTableProps) => {
                     ? "indeterminate"
                     : false
               }
-              onChange={tableInstance.getToggleAllRowsSelectedHandler()}
+              onCheckedChange={() => tableInstance.toggleAllRowsSelected(!tableInstance.getIsAllRowsSelected())}
             >
               <Checkbox.HiddenInput />
               <Checkbox.Control />
@@ -459,7 +459,7 @@ const DataTable = (props: DataTableProps) => {
             getIsSelected: () => boolean;
             getIsSomeSelected: () => boolean;
             getCanSelect: () => boolean;
-            getToggleSelectedHandler: () => (event: unknown) => void;
+            toggleSelected: (value?: boolean) => void;
           };
         }) => (
           <Flex align="center" justify="center" w="100%" h="100%">
@@ -468,7 +468,7 @@ const DataTable = (props: DataTableProps) => {
               colorPalette="blue"
               checked={row.getIsSelected() ? true : row.getIsSomeSelected() ? "indeterminate" : false}
               disabled={!row.getCanSelect() || props.viewOnly}
-              onChange={row.getToggleSelectedHandler()}
+              onCheckedChange={() => row.toggleSelected(!row.getIsSelected())}
             >
               <Checkbox.HiddenInput />
               <Checkbox.Control />
@@ -759,6 +759,7 @@ const DataTable = (props: DataTableProps) => {
 
   const headerGroups = table.getHeaderGroups();
   const rows = table.getRowModel().rows;
+  const selectedCount = Object.values(selectedRows).filter(Boolean).length;
 
   const calculateTotalMinWidth = useCallback(() => {
     const visibleHeaders = headerGroups[0]?.headers.filter((header) => header.column.getIsVisible()) || [];
@@ -1067,6 +1068,8 @@ const DataTable = (props: DataTableProps) => {
                           _.isUndefined(props.actions) ||
                           props.actions?.length === 0) &&
                         !action.alwaysEnabled;
+                      const resolvedLabel =
+                        typeof action.label === "function" ? action.label(selectedCount) : action.label;
                       return (
                         <Menu.Item
                           onClick={() => {
@@ -1074,13 +1077,13 @@ const DataTable = (props: DataTableProps) => {
                               action.action(table, selectedRows);
                             }
                           }}
-                          key={action.label}
+                          key={resolvedLabel}
                           disabled={isDisabled || action.disabled}
-                          value={action.label}
+                          value={resolvedLabel}
                         >
                           <Flex direction="row" gap="1" align="center">
                             <Icon name={action.icon} size="xs" />
-                            <Text fontSize="xs">{action.label}</Text>
+                            <Text fontSize="xs">{resolvedLabel}</Text>
                           </Flex>
                         </Menu.Item>
                       );

--- a/client/src/components/Linky/index.tsx
+++ b/client/src/components/Linky/index.tsx
@@ -115,7 +115,7 @@ const Linky = (props: LinkyProps) => {
   const getLinkyData = async () => {
     // If id is empty or missing, just use fallback without making a query
     if (!props.id || props.id.trim() === "") {
-      const fallbackName = props.fallback || "Invalid Link";
+      const fallbackName = props.fallback || `Invalid ${_.capitalize(props.type).slice(0, -1)}`;
       setTooltipLabel(fallbackName);
       setShowDeleted(true);
 
@@ -132,7 +132,7 @@ const Linky = (props: LinkyProps) => {
 
     const data: IGenericItem & { description: string } = {
       _id: props.id,
-      name: props.fallback || "Invalid Link",
+      name: props.fallback || `Invalid ${_.capitalize(props.type.slice(-1))}`,
       description: "",
     };
 
@@ -141,7 +141,8 @@ const Linky = (props: LinkyProps) => {
         const response = await getTemplate({ variables: { _id: props.id } });
         if (response.error || _.isUndefined(response.data)) {
           setShowDeleted(true);
-          setTooltipLabel("Error accessing Template");
+          data.name = "Invalid Template";
+          setTooltipLabel(`The Template (ID: ${props.id}) is either inaccessible or does not exist.`);
         } else {
           data.name = response.data.template.name;
           setTooltipLabel(data.name);
@@ -153,7 +154,8 @@ const Linky = (props: LinkyProps) => {
         const response = await getEntity({ variables: { _id: props.id } });
         if (response.error || _.isUndefined(response.data)) {
           setShowDeleted(true);
-          setTooltipLabel("Error accessing Entity");
+          data.name = "Invalid Entity";
+          setTooltipLabel(`The Entity (ID: ${props.id}) is either inaccessible or does not exist.`);
         } else {
           data.name = response.data.entity.name;
           setTooltipLabel(data.name);
@@ -165,7 +167,8 @@ const Linky = (props: LinkyProps) => {
         const response = await getProject({ variables: { _id: props.id } });
         if (response.error || _.isUndefined(response.data)) {
           setShowDeleted(true);
-          setTooltipLabel("Error accessing Project");
+          data.name = "Invalid Project";
+          setTooltipLabel(`The Project (ID: ${props.id}) is either inaccessible or does not exist.`);
         } else {
           data.name = response.data.project.name;
           setTooltipLabel(data.name);
@@ -177,7 +180,8 @@ const Linky = (props: LinkyProps) => {
     } catch (error) {
       // If query fails completely, use fallback
       setShowDeleted(true);
-      setTooltipLabel("Invalid Link");
+      const tooltipLabel = `The ${_.capitalize(props.type.slice(0, -1))} (ID: ${props.id}) is either inaccessible or does not exist.`;
+      setTooltipLabel(tooltipLabel);
     }
 
     // Set the label text and apply truncating where specified
@@ -265,13 +269,13 @@ const Linky = (props: LinkyProps) => {
               <Flex
                 align={"center"}
                 justify={"center"}
-                bg={badgeBg}
+                bg={showArchived ? "gray.50" : badgeBg}
                 px={"1.5"}
                 h={"100%"}
                 borderRight={"1px solid"}
                 borderColor={badgeBorder}
               >
-                <Icon name={icon} size={"xs"} color={iconColor} />
+                <Icon name={icon} size={"xs"} color={showArchived ? "gray.500" : iconColor} />
               </Flex>
               {/* Name */}
               <Flex px={"2"} align={"center"} h={"100%"} bg={"white"}>

--- a/client/src/components/Values/index.tsx
+++ b/client/src/components/Values/index.tsx
@@ -13,6 +13,7 @@ import {
   Flex,
   IconButton,
   Input,
+  Menu,
   Portal,
   Select,
   Separator,
@@ -621,6 +622,29 @@ const Values = (props: {
   // State for row selection and manipulation
   const [selectedRows, setSelectedRows] = useState<Set<string>>(new Set());
 
+  const allSelected = props.values.length > 0 && props.values.every((v) => selectedRows.has(v._id));
+  const someSelected = !allSelected && props.values.some((v) => selectedRows.has(v._id));
+
+  const toggleSelectRow = (id: string) => {
+    setSelectedRows((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  };
+
+  const toggleSelectAll = () => {
+    if (allSelected) {
+      setSelectedRows(new Set());
+    } else {
+      setSelectedRows(new Set(props.values.map((v) => v._id)));
+    }
+  };
+
   // State for pagination
   const [currentPage, setCurrentPage] = useState(1);
   const [rowsPerPage, setRowsPerPage] = useState(10);
@@ -740,21 +764,32 @@ const Values = (props: {
         >
           {/* Header Row */}
           <Flex gap={0} bg="gray.100" borderBottom="1px solid" borderColor="gray.200" direction="row">
-            {/* Drag Handle Column Header */}
+            {/* Select Column Header */}
             {!props.viewOnly && (
-              <Box
+              <Flex
                 w="40px"
                 flex={"0 0 auto"}
                 minW="40px"
                 px={1}
                 py={1}
-                textAlign="center"
+                align="center"
+                justify="center"
                 bg="gray.100"
                 borderRight="1px solid"
                 borderColor="gray.200"
                 overflow="hidden"
                 flexShrink={0}
-              />
+              >
+                <Checkbox.Root
+                  checked={allSelected ? true : someSelected ? "indeterminate" : false}
+                  onCheckedChange={toggleSelectAll}
+                  size="xs"
+                  colorPalette="blue"
+                >
+                  <Checkbox.HiddenInput />
+                  <Checkbox.Control />
+                </Checkbox.Root>
+              </Flex>
             )}
 
             {/* Name Column Header */}
@@ -873,6 +908,7 @@ const Values = (props: {
                 key={value._id}
                 value={value}
                 onValueChange={onValueChange}
+                onToggleSelect={() => toggleSelectRow(value._id)}
                 columnWidths={columnWidths}
                 isSelected={selectedRows.has(value._id)}
                 hideBorder={index >= paginatedValues.length - 1}
@@ -881,43 +917,25 @@ const Values = (props: {
             ))}
           </Box>
 
-          {/* Add or Delete Selected Rows Button */}
+          {/* Add Row Button */}
           {!props.viewOnly && (
             <Flex borderTop="1px solid" borderColor="gray.200" p={0} justify="center" align="center" bg="gray.100">
-              {selectedRows.size > 0 ? (
-                <Button
-                  size="xs"
-                  variant="ghost"
-                  colorPalette="red"
-                  onClick={removeSelectedRows}
-                  aria-label="Delete selected values"
-                  w="100%"
-                  h={"fit-content"}
-                  p={"0.5"}
-                >
-                  <Icon name="delete" size="xs" />
-                  <Text ml={1} fontSize="xs" fontWeight="semibold">
-                    Delete {selectedRows.size === 1 ? "Value" : "Values"} ({selectedRows.size})
-                  </Text>
-                </Button>
-              ) : (
-                <Button
-                  id="addValueRowButton"
-                  size="xs"
-                  variant="ghost"
-                  colorPalette="green"
-                  onClick={addRow}
-                  aria-label="Add value"
-                  w="100%"
-                  h={"fit-content"}
-                  p={"0.5"}
-                >
-                  <Icon name="add" size="xs" />
-                  <Text ml={1} fontSize="xs" fontWeight="semibold">
-                    Add Value
-                  </Text>
-                </Button>
-              )}
+              <Button
+                id="addValueRowButton"
+                size="xs"
+                variant="ghost"
+                colorPalette="green"
+                onClick={addRow}
+                aria-label="Add value"
+                w="100%"
+                h={"fit-content"}
+                p={"0.5"}
+              >
+                <Icon name="add" size="xs" />
+                <Text ml={1} fontSize="xs" fontWeight="semibold">
+                  Add Value
+                </Text>
+              </Button>
             </Flex>
           )}
         </Box>
@@ -985,6 +1003,32 @@ const Values = (props: {
           >
             <Icon name="c_double_right" />
           </IconButton>
+          {!props.viewOnly && (
+            <Menu.Root>
+              <Menu.Trigger asChild>
+                <Button colorPalette="yellow" size="xs" rounded="md">
+                  Actions
+                  <Icon name="lightning" size="xs" />
+                </Button>
+              </Menu.Trigger>
+              <Menu.Positioner>
+                <Menu.Content p={1} rounded="md">
+                  <Menu.Item
+                    value="remove"
+                    disabled={selectedRows.size === 0}
+                    onClick={() => {
+                      if (selectedRows.size > 0) removeSelectedRows();
+                    }}
+                  >
+                    <Flex direction="row" gap="1" align="center">
+                      <Icon name="delete" size="xs" />
+                      <Text fontSize="xs">Remove Values ({selectedRows.size})</Text>
+                    </Flex>
+                  </Menu.Item>
+                </Menu.Content>
+              </Menu.Positioner>
+            </Menu.Root>
+          )}
         </Flex>
 
         <Flex direction="row" gap={1} align="center" wrap="wrap">
@@ -1050,6 +1094,7 @@ const ValueRow = (props: {
   key: string;
   value: IValue;
   onValueChange: (_id: string, name: string, type: IValueType, data: string) => void;
+  onToggleSelect: () => void;
   columnWidths: { type: number; name: number; value: number };
   isSelected: boolean;
   hideBorder?: boolean;
@@ -1072,7 +1117,6 @@ const ValueRow = (props: {
   const [valueType, setValueType] = useState<IValueType>(props.value.type);
   const [valueTypeOption, setValueTypeOption] = useState<ValueTypeOption>(initialValueType);
   const [valueData, setValueData] = useState<string>(props.value.data);
-  const [valueChecked, setValueChecked] = useState(false);
 
   useEffect(() => {
     // Propagate changes to overall `Value` state
@@ -1490,8 +1534,8 @@ const ValueRow = (props: {
           cursor={props.viewOnly ? "default" : "pointer"}
         >
           <Checkbox.Root
-            checked={valueChecked}
-            onChange={() => setValueChecked(!valueChecked)}
+            checked={props.isSelected}
+            onCheckedChange={() => props.onToggleSelect()}
             size="xs"
             colorPalette="blue"
             disabled={props.viewOnly}

--- a/client/src/pages/create/Template.tsx
+++ b/client/src/pages/create/Template.tsx
@@ -295,7 +295,7 @@ const Template = () => {
               <Field.Root required gap={"1"}>
                 <Flex direction={"column"} gap={"0.5"} ml={"0.5"}>
                   <Field.Label fontSize={"xs"} fontWeight={"semibold"}>
-                    Template Value
+                    Template Values
                     <Field.RequiredIndicator />
                   </Field.Label>
                   <Text fontSize={"xs"}>

--- a/client/src/pages/view/Entities.tsx
+++ b/client/src/pages/view/Entities.tsx
@@ -353,7 +353,7 @@ const Entities = () => {
 
   const actions: DataTableAction[] = [
     {
-      label: `Export Selected`,
+      label: (count: number) => `Export Selected (${count})`,
       icon: "download",
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       action: async (table, rows: any) => {

--- a/client/src/pages/view/Entity.tsx
+++ b/client/src/pages/view/Entity.tsx
@@ -2221,7 +2221,7 @@ const Entity = () => {
                   <EmptyState.Root>
                     <EmptyState.Content>
                       <EmptyState.Indicator>
-                        <Icon name={"attribute"} size={"lg"} />
+                        <Icon name={"attribute"} size={"lg"} color={GLOBAL_STYLES.template.lightColor} />
                       </EmptyState.Indicator>
                       <EmptyState.Description>No Attributes</EmptyState.Description>
                     </EmptyState.Content>

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -447,7 +447,7 @@ export type DataTableProps = {
 };
 
 export type DataTableAction = {
-  label: string; // Action label
+  label: string | ((selectedCount: number) => string); // Action label, or a function receiving the selected row count
   icon: IconNames; // Icon
   action: (table: any, rows: any) => void; // Action function acting on the provided the table and rows
   disabled?: boolean; // Disable the action


### PR DESCRIPTION
# Pull Request

## Description

* Fix the checkbox selection components on both `DataTable` and `Values`, addressing issues un-selecting and adding a counter for selected items
* Add `Actions` menu to `Values`, allowing selected items to be removed
* Update `Linky` appearance to be more specific to the `type` specified in the `props`

## Ticket

https://ccdresearch.atlassian.net/browse/MARS-1160