### PR TITLE
MARS-1182-User-api_keys-not-serialized-to-string-correctly

### DIFF
--- a/client/src/lib/auth.ts
+++ b/client/src/lib/auth.ts
@@ -28,7 +28,7 @@ export const auth = createAuthClient({
           type: "boolean",
         },
         api_keys: {
-          type: "string[]",
+          type: "string",
         },
         account_orcid: {
           type: "string",

--- a/client/src/pages/account/Signup.tsx
+++ b/client/src/pages/account/Signup.tsx
@@ -258,7 +258,7 @@ const Signup = () => {
           lastName: userLastName,
           affiliation: userAffiliation,
           lastLogin: dayjs(Date.now()).toISOString(),
-          api_keys: [],
+          api_keys: JSON.stringify([]),
           account_orcid: orcidId,
           callbackURL: "/login",
           hasSeenWalkthrough: false,

--- a/client/src/pages/account/Signup.tsx
+++ b/client/src/pages/account/Signup.tsx
@@ -260,7 +260,7 @@ const Signup = () => {
           lastLogin: dayjs(Date.now()).toISOString(),
           api_keys: JSON.stringify([]),
           account_orcid: orcidId,
-          callbackURL: "/login",
+          callbackURL: `${APP_URL}/login`,
           hasSeenWalkthrough: false,
         },
         {

--- a/client/test/playwright/ui/attribute.test.ts
+++ b/client/test/playwright/ui/attribute.test.ts
@@ -104,12 +104,12 @@ test.describe("Template", () => {
       const user = await createTestUser(context);
 
       // Setup Workspace and Templates
-      const workspace = await createTestWorkspace("Templates-4", user);
+      const workspace = await createTestWorkspace("Template-4", user);
       await createTestTemplate("1-Template-Archive", user, workspace);
 
       // Navigate for tests
       await page.goto("/");
-      await switchWorkspace(page, "Templates-4");
+      await switchWorkspace(page, "Template-4");
     });
 
     test("archives and restores a Template", async ({ page }) => {
@@ -136,14 +136,14 @@ test.describe("Template", () => {
       const user = await createTestUser(context);
 
       // Setup Workspace and Templates
-      const workspace = await createTestWorkspace("Templates-5", user);
+      const workspace = await createTestWorkspace("Template-5", user);
       await createTestEntity("1-Attribute-Text-Entity", user, workspace);
       await createTestEntity("2-Attribute-Multi-Entity", user, workspace);
       await createTestEntity("3-Attribute-Delete-Entity", user, workspace);
 
       // Navigate for tests
       await page.goto("/");
-      await switchWorkspace(page, "Templates-5");
+      await switchWorkspace(page, "Template-5");
     });
 
     test("should add a text Attribute to an Entity and persist after reload", async ({ page }) => {

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -7,14 +7,15 @@
     "declaration": false,
     "sourceMap": true,
     "inlineSources": true,
+    "baseUrl": "./",
     "paths": {
-      "@components/*": ["./src/components/*"],
-      "@database/*": ["./src/database/*"],
-      "@hooks/*": ["./src/hooks/*"],
-      "@lib/*": ["./src/lib/*"],
-      "@pages/*": ["./src/pages/*"],
+      "@components/*": ["src/components/*"],
+      "@database/*": ["src/database/*"],
+      "@hooks/*": ["src/hooks/*"],
+      "@lib/*": ["src/lib/*"],
+      "@pages/*": ["src/pages/*"],
       "@types": ["../types"],
-      "@variables": ["./src/variables"]
+      "@variables": ["src/variables"]
     },
     "rootDirs": ["src"],
     "strict": true,

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -7,15 +7,14 @@
     "declaration": false,
     "sourceMap": true,
     "inlineSources": true,
-    "baseUrl": "./",
     "paths": {
-      "@components/*": ["src/components/*"],
-      "@database/*": ["src/database/*"],
-      "@hooks/*": ["src/hooks/*"],
-      "@lib/*": ["src/lib/*"],
-      "@pages/*": ["src/pages/*"],
+      "@components/*": ["./src/components/*"],
+      "@database/*": ["./src/database/*"],
+      "@hooks/*": ["./src/hooks/*"],
+      "@lib/*": ["./src/lib/*"],
+      "@pages/*": ["./src/pages/*"],
       "@types": ["../types"],
-      "@variables": ["src/variables"]
+      "@variables": ["./src/variables"]
     },
     "rootDirs": ["src"],
     "strict": true,

--- a/server/src/lib/auth.ts
+++ b/server/src/lib/auth.ts
@@ -160,7 +160,7 @@ export const auth = betterAuth({
         defaultValue: false,
       },
       api_keys: {
-        type: "string[]",
+        type: "string",
       },
       account_orcid: {
         type: "string",

--- a/server/src/models/API.ts
+++ b/server/src/models/API.ts
@@ -80,7 +80,7 @@ export class API {
     }
 
     // `api_keys` is stored as a JSON string by better-auth, parse before filtering
-    const parsedKeys: APIKey[] = JSON.parse(apiUser.api_keys as unknown as string);
+    const parsedKeys: APIKey[] = JSON.parse(apiUser.api_keys);
     const apiKey = parsedKeys.filter((key) => _.isEqual(key.value, providedKey)).pop();
     if (_.isUndefined(apiKey)) {
       const responseData: APIData<object> = {

--- a/server/src/models/User.ts
+++ b/server/src/models/User.ts
@@ -204,7 +204,7 @@ export class User {
     return (
       users.find((user) => {
         if (!user.api_keys) return false;
-        const keys: APIKey[] = JSON.parse(user.api_keys as unknown as string);
+        const keys: APIKey[] = JSON.parse(user.api_keys);
         return keys.some((k) => k.value === api_key);
       }) ?? null
     );

--- a/server/test/helpers.ts
+++ b/server/test/helpers.ts
@@ -370,7 +370,7 @@ export const getAuth = async () => {
             defaultValue: false,
           },
           api_keys: {
-            type: "string[]",
+            type: "string",
           },
           account_orcid: {
             type: "string",


### PR DESCRIPTION
# Pull Request

## Description

* Fixed bug where User `api_key` field wasn't being serialized correctly from JSON to string representation
* Fixed some outstanding issues in Playwright tests

## Ticket

https://ccdresearch.atlassian.net/browse/MARS-1182